### PR TITLE
Revert to using YAML coder for device tags

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,6 +1,6 @@
 class Device < ApplicationRecord
   self.primary_key = :uuid
-  serialize :tags, coder: JSON
+  serialize :tags, coder: YAML
   serialize :disks, coder: JSON
   serialize :gpus, coder: JSON
   belongs_to :user, optional: true


### PR DESCRIPTION
Fixes an issue where tags were stored in YAML format but were attempted to be parsed as JSON