### PR TITLE
Implement server-side Boavizta requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem "devise"
 
 gem "jwt"
 
+gem "faraday"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
       warden (~> 1.2.3)
     drb (2.2.1)
     erubi (1.12.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.4)
@@ -139,6 +143,8 @@ GEM
     minitest (5.22.3)
     msgpack (1.7.2)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.10)
       date
       net-protocol
@@ -235,6 +241,7 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
+    uri (0.13.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -261,6 +268,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  faraday
   importmap-rails
   jbuilder
   jwt

--- a/app/controllers/device_controller.rb
+++ b/app/controllers/device_controller.rb
@@ -1,8 +1,12 @@
 class DeviceController < ApplicationController
   before_action :authorize_request, :only=>[:add_tag, :delete_tag]
 
-  def show
+  def index
     @devices = Device.all
+  end
+
+  def show
+    @device = Device.find(params[:device])
   end
 
   def raw_data

--- a/app/controllers/device_controller.rb
+++ b/app/controllers/device_controller.rb
@@ -6,14 +6,14 @@ class DeviceController < ApplicationController
   end
 
   def raw_data
-    devices = Device.left_joins(:user)
+    devices = Device.left_joins(:user) # This join is still necessary for the future leaderboard to include usernames
     .select('devices.*, users.username, max / (cpus * cores_per_cpu) AS max_per_core')
     .order(:max_per_core)
     response = {}.tap do |res|
       max_device = devices.last
       res[:max_main] = max_device&.max_per_core&.round(3);
       res[:header] = {}.tap do |h|
-        h[:user] = 'User'
+        h[:user] = 'Name'
         h[:platform] = 'Platform'
         h[:location] = 'Location'
         h[:core_number] = 'No. cores'
@@ -29,7 +29,7 @@ class DeviceController < ApplicationController
         dev_group.map do |dev|
           {}.tap do |new_dev|
             new_dev[:rank] = current_rank
-            new_dev[:user] = dev.username || 'Anonymous'
+            new_dev[:user] = dev.display_name
             new_dev[:platform] = dev.platform
             new_dev[:location] = dev.location
             new_dev[:core_number] = dev.cpus * dev.cores_per_cpu

--- a/app/controllers/device_controller.rb
+++ b/app/controllers/device_controller.rb
@@ -6,7 +6,7 @@ class DeviceController < ApplicationController
   end
 
   def show
-    @device = Device.find(params[:device])
+    @device = Device.find_by(display_name: params[:device])
   end
 
   def raw_data
@@ -47,7 +47,7 @@ class DeviceController < ApplicationController
   end
 
   def add_tag
-    device = Device.find(params[:device])
+    device = Device.find_by(display_name: params[:device])
     if device.user_id == @current_user.id
       report.add_tag(request.body.read)
     else
@@ -56,7 +56,7 @@ class DeviceController < ApplicationController
   end
 
   def delete_tag
-    device = Device.find(params[:device])
+    device = Device.find_by(display_name: params[:device])
     if device.user_id == @current_user.id
       report.delete_tag(request.body.read)
     else

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -44,7 +44,7 @@ class ReportController < ApplicationController
     end
 
     report = Report.new(device_id: device.uuid,
-                        current: Boavizta.carbon_for_load(device, data['current']) # Update when current renamed
+                        current: Boavizta.carbon_for_load(device, data['current_load'])
                        )
 
     if report.valid?

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -16,6 +16,7 @@ class ReportController < ApplicationController
     device = Device.find_by(uuid: data['device_id'])
     if !device
       device = Device.new(uuid: data['device_id'],
+                          display_name: new_name,
                           user_id: @current_user&.id,
                           cpus: data['cpus'],
                           cores_per_cpu: data['cores_per_cpu'],
@@ -52,7 +53,19 @@ class ReportController < ApplicationController
       return
     end
 
-    render json: "Report saved successfully: Current carbon usage of #{data['current']}kgCO2eq saved for #{@current_user ? @current_user.username : 'anonymous user'}."
+    render json: "Report saved successfully: Current carbon usage of #{data['current']}kgCO2eq saved for #{@current_user ? @current_user.username : 'an anonymous user'}'s device '#{device.display_name}'"
+  end
+
+  def new_name
+    colours = %w(red orange yellow green blue indigo violet pink purple grey)
+    adjs = %w(big small quick slow mad calm good bad brave lucky)
+    animals = %w(dog cat chicken duck otter lion tiger fish snake dragon)
+
+    name = "#{adjs[rand(10)]}_#{colours[rand(10)]}_#{animals[rand(10)]}#{rand(100)}"
+    while Device.find_by(display_name: name)
+      name = "#{adjs[rand(10)]}_#{colours[rand(10)]}_#{animals[rand(10)]}#{rand(100)}"
+    end
+    name
   end
 end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -57,13 +57,13 @@ class ReportController < ApplicationController
   end
 
   def new_name
-    colours = %w(red orange yellow green blue indigo violet pink purple grey)
-    adjs = %w(big small quick slow mad calm good bad brave lucky)
-    animals = %w(dog cat chicken duck otter lion tiger fish snake dragon)
+    colours = %w(Red Orange Yellow Green blue Indigo Violet Pink Purple Grey)
+    adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
+    animals = %w(Dog Cat Chicken Duck Otter Lion Tiger Fish Snake Dragon)
 
-    name = "#{adjs[rand(10)]}_#{colours[rand(10)]}_#{animals[rand(10)]}#{rand(100)}"
+    name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
     while Device.find_by(display_name: name)
-      name = "#{adjs[rand(10)]}_#{colours[rand(10)]}_#{animals[rand(10)]}#{rand(100)}"
+      name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
     end
     name
   end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -58,7 +58,7 @@ class ReportController < ApplicationController
   end
 
   def new_name
-    colours = %w(Red Orange Yellow Green blue Indigo Violet Pink Purple Grey)
+    colours = %w(Red Orange Yellow Green Blue Indigo Violet Pink Purple Grey)
     adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
     animals = %w(Dog Cat Chicken Duck Otter Lion Tiger Fish Snake Dragon)
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -27,12 +27,12 @@ class ReportController < ApplicationController
                           disks: data['disk'] || [],
                           gpus: data['gpu'] || [],
                           platform: data['platform'],
-                          instance_type: data['instance_type'],
                           location: data['location'],
                           tags: data['tags'] || []
                          )
       if device.valid?
         device.cloud_provider = Boavizta.provider(device.platform)
+        device.instance_type = data['instance_type'] if Boavizta.type_exists?(data['instance_type'], device.cloud_provider)
         device.min = Boavizta.carbon_for_load(device, 0)
         device.half = Boavizta.carbon_for_load(device, 50)
         device.max = Boavizta.carbon_for_load(device, 100)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -27,12 +27,12 @@ class ReportController < ApplicationController
                           disks: data['disk'] || [],
                           gpus: data['gpu'] || [],
                           platform: data['platform'],
-                          cloud_provider: data['cloud_provider'],
                           instance_type: data['instance_type'],
                           location: data['location'],
                           tags: data['tags'] || []
                          )
       if device.valid?
+        device.cloud_provider = Boavizta.provider(device.platform)
         device.min = Boavizta.carbon_for_load(device, 0)
         device.half = Boavizta.carbon_for_load(device, 50)
         device.max = Boavizta.carbon_for_load(device, 100)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -33,13 +33,24 @@ class ReportController < ApplicationController
                           location: data['location'],
                           tags: data['tags'] || []
                          )
-      device.save
+      if device.valid?
+        device.save
+      else
+        render json: "Error(s) with payload data: #{device.errors.full_messages.join(', ')}"
+        return
+      end
     end
 
     report = Report.new(device_id: device.uuid,
                         current: data['current']
                        )
-    report.save
+        
+    if report.valid?
+      report.save
+    else
+      render json: "Error(s) with payload data: #{report.errors.full_messages.join(', ')}"
+      return
+    end
 
     render json: "Report saved successfully: Current carbon usage of #{data['current']}kgCO2eq saved for #{@current_user ? @current_user.username : 'anonymous user'}."
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,11 +10,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  def create
-    super
-    current_user.auth_token = JsonWebToken.encode(user_id: @user.id)
-    current_user.save
-  end
+  #def create
+  #  super
+  #end
 
   # GET /resource/edit
   # def edit
@@ -53,9 +51,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    current_user.auth_token = JsonWebToken.encode(user_id: @user.id)
+    current_user.save
+    super(resource)
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -3,8 +3,12 @@ class Device < ApplicationRecord
   serialize :tags, coder: JSON
   serialize :disks, coder: JSON
   serialize :gpus, coder: JSON
+
   belongs_to :user, optional: true
   has_many :reports, dependent: :destroy
+
+  validates :uuid, :cpus, :cores_per_cpu, :ram_units, :ram_capacity_per_unit, :min, :half,
+            :max, :platform, :location, :cpu_name, :cloud_provider, presence: { message: "is required" }
 
   def pretty_owner
     User.find_by(id: self.user_id)&.username || "Anonymous"

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -7,8 +7,8 @@ class Device < ApplicationRecord
   belongs_to :user, optional: true
   has_many :reports, dependent: :destroy
 
-  validates :uuid, :cpus, :cores_per_cpu, :ram_units, :ram_capacity_per_unit, :min, :half,
-            :max, :platform, :location, :cpu_name, :cloud_provider, presence: { message: "is required" }
+  validates :uuid, :cpus, :cores_per_cpu, :ram_units, :ram_capacity_per_unit, :platform,
+            :location, :cpu_name, :cloud_provider, presence: { message: "is required" }
 
   def pretty_owner
     User.find_by(id: self.user_id)&.username || "Anonymous"

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -8,7 +8,7 @@ class Device < ApplicationRecord
   has_many :reports, dependent: :destroy
 
   validates :uuid, :cpus, :cores_per_cpu, :ram_units, :ram_capacity_per_unit, :platform,
-            :location, :cpu_name, :cloud_provider, presence: { message: "is required" }
+            :location, :cpu_name, presence: { message: "is required" }
 
   def pretty_owner
     User.find_by(id: self.user_id)&.username || "Anonymous"

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,7 +2,7 @@ class Report < ApplicationRecord
   belongs_to :device
   has_one :user, through: :device
 
-  validates :current, presence: { message: "is required" }
+  validates :current, presence: { message: "carbon usage could not be calculated" }
 
   def add_tag(tag)
     self.tags |= [tag]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,7 +2,7 @@ class Report < ApplicationRecord
   belongs_to :device
   has_one :user, through: :device
 
-  validates :current, presence: ( message: "is required" }
+  validates :current, presence: { message: "is required" }
 
   def add_tag(tag)
     self.tags |= [tag]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,6 +2,8 @@ class Report < ApplicationRecord
   belongs_to :device
   has_one :user, through: :device
 
+  validates :current, presence: ( message: "is required" }
+
   def add_tag(tag)
     self.tags |= [tag]
     self.tags.sort!

--- a/app/views/device/index.html.erb
+++ b/app/views/device/index.html.erb
@@ -1,0 +1,65 @@
+<h1>Recorded Devices</h1>
+
+<style>
+table, th, td {
+  border:1px solid black;
+}
+td {
+  text-align: center;
+}
+</style>
+
+<table style="width:100%" align="right">
+  <tr>
+    <th>Device Name</th>
+    <th>Owner</th>
+    <th>CPU name</th>
+    <th>CPUs</th>
+    <th>Cores Per CPU</th>
+    <th>RAM Units</th>
+    <th>RAM Capacity Per Unit</th>
+    <th>Disks</th>
+    <th>GPUs</th>
+    <th>Carbon Usage (min)</th>
+    <th>Carbon Usage (half)</th>
+    <th>Carbon Usage (max)</th>
+    <th>Platform</th>
+    <th>Cloud Provider ID</th>
+    <th>Instance Type</th>
+    <th>Location</th>
+    <th>Tags</th>
+  </tr>
+  <% @devices.each do |device| %>
+    <tr>
+      <td>
+        <a href="/devices/<%= device.uuid %>">
+          <%= device.display_name %>
+        </a>
+      </td>
+      <td><%= username(device.user_id) %></td>
+      <td><%= device.cpu_name %></td>
+      <td><%= device.cpus %></td>
+      <td><%= device.cores_per_cpu %></td>
+      <td><%= device.ram_units %></td>
+      <td><%= device.ram_capacity_per_unit %></td>
+      <td>
+        <%=
+        disk_string = ""
+        device.disks.each do |disk|
+          disk_string << "#{disk['units']} x #{disk['capacity']}GB #{disk['type'].upcase}\n"
+        end
+        simple_format(disk_string)
+        %>
+      </td>
+      <td><%= device.gpus %></td>
+      <td><%= device.min %></td>
+      <td><%= device.half %></td>
+      <td><%= device.max %></td>
+      <td><%= device.platform %></td>
+      <td><%= device.cloud_provider %></td>
+      <td><%= device.instance_type %></td>
+      <td><%= device.location %></td>
+      <td><%= device.tags.join(", ") %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/device/index.html.erb
+++ b/app/views/device/index.html.erb
@@ -32,7 +32,7 @@ td {
   <% @devices.each do |device| %>
     <tr>
       <td>
-        <a href="/devices/<%= device.uuid %>">
+        <a href="/devices/<%= device.display_name %>">
           <%= device.display_name %>
         </a>
       </td>

--- a/app/views/device/index.html.erb
+++ b/app/views/device/index.html.erb
@@ -32,7 +32,7 @@ td {
   <% @devices.each do |device| %>
     <tr>
       <td>
-        <a href="/devices/<%= device.display_name %>">
+        <a href="/device/<%= device.display_name %>">
           <%= device.display_name %>
         </a>
       </td>

--- a/app/views/device/show.html.erb
+++ b/app/views/device/show.html.erb
@@ -9,6 +9,8 @@ td {
 }
 </style>
 
+<h2>Specs</h2>
+
 <table style="width:100%" align="right">
   <tr>
     <th>Owner</th>
@@ -54,4 +56,24 @@ td {
     <td><%= @device.location %></td>
     <td><%= @device.tags.join(", ") %></td>
   </tr>
+</table>
+
+<h2>Latest Entries</h2>
+
+<table style="width:100%" align="right">
+  <tr>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Carbon Usage Per Hour</th>
+    <th>Percentage of maximum carbon usage</th>
+  </tr>
+  <% @device.reports.each do |report| %>
+    <tr>
+      <% time = report.created_at.to_time %>
+      <td><%= time.strftime("%d/%m/%Y") %></td>
+      <td><%= time.strftime("%l:%M%p UTC") %></td>
+      <td><%= report.current%></td>
+      <td><%= "#{(report.current / @device.max * 100).round(1)}%"%></td>
+    </tr>
+  <% end %>
 </table>

--- a/app/views/device/show.html.erb
+++ b/app/views/device/show.html.erb
@@ -1,17 +1,16 @@
-<h1>Recorded Devices</h1>
+<h1><%= "Info for device #{@device.display_name}" %> </h1>
 
 <style>
 table, th, td {
   border:1px solid black;
 }
 td {
-	text-align: center;
+  text-align: center;
 }
 </style>
 
 <table style="width:100%" align="right">
   <tr>
-    <th>Device Name</th>
     <th>Owner</th>
     <th>CPU name</th>
     <th>CPUs</th>
@@ -29,33 +28,30 @@ td {
     <th>Location</th>
     <th>Tags</th>
   </tr>
-	<% @devices.each do |device| %>
-	  <tr>
-	    <td><%= device.display_name %></td>
-			<td><%= username(device.user_id) %></td>
-	    <td><%= device.cpu_name %></td>
-	    <td><%= device.cpus %></td>
-	    <td><%= device.cores_per_cpu %></td>
-	    <td><%= device.ram_units %></td>
-	    <td><%= device.ram_capacity_per_unit %></td>
-	    <td>
-	      <%=
-	      disk_string = ""
-	      device.disks.each do |disk|
-	        disk_string << "#{disk['units']} x #{disk['capacity']}GB #{disk['type'].upcase}\n"
-	      end
-	      simple_format(disk_string)
-	      %>
-	    </td>
-	    <td><%= device.gpus %></td>
-	    <td><%= device.min %></td>
-	    <td><%= device.half %></td>
-	    <td><%= device.max %></td>
-	    <td><%= device.platform %></td>
-	    <td><%= device.cloud_provider %></td>
-	    <td><%= device.instance_type %></td>
-	    <td><%= device.location %></td>
-	    <td><%= device.tags.join(", ") %></td>
-		</tr>
-	<% end %>
+  <tr>
+    <td><%= username(@device.user_id) %></td>
+    <td><%= @device.cpu_name %></td>
+    <td><%= @device.cpus %></td>
+    <td><%= @device.cores_per_cpu %></td>
+    <td><%= @device.ram_units %></td>
+    <td><%= @device.ram_capacity_per_unit %></td>
+    <td>
+      <%=
+      disk_string = ""
+      @device.disks.each do |disk|
+        disk_string << "#{disk['units']} x #{disk['capacity']}GB #{disk['type'].upcase}\n"
+      end
+      simple_format(disk_string)
+      %>
+    </td>
+    <td><%= @device.gpus %></td>
+    <td><%= @device.min %></td>
+    <td><%= @device.half %></td>
+    <td><%= @device.max %></td>
+    <td><%= @device.platform %></td>
+    <td><%= @device.cloud_provider %></td>
+    <td><%= @device.instance_type %></td>
+    <td><%= @device.location %></td>
+    <td><%= @device.tags.join(", ") %></td>
+  </tr>
 </table>

--- a/app/views/device/show.html.erb
+++ b/app/views/device/show.html.erb
@@ -11,7 +11,7 @@ td {
 
 <table style="width:100%" align="right">
   <tr>
-    <th>Device UUID</th>
+    <th>Device Name</th>
     <th>Owner</th>
     <th>CPU name</th>
     <th>CPUs</th>
@@ -31,7 +31,7 @@ td {
   </tr>
 	<% @devices.each do |device| %>
 	  <tr>
-	    <td><%= device.uuid %></td>
+	    <td><%= device.display_name %></td>
 			<td><%= username(device.user_id) %></td>
 	    <td><%= device.cpu_name %></td>
 	    <td><%= device.cpus %></td>

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -180,8 +180,8 @@ ask_question() {
     VAL="$2"
     VALIDATION="$3"
     correct="placeholder"
-    while [[ $correct != [yY] && $correct != [yY][eE][sS] && $correct != [nN] && $correct != [nN][oO] ]] ; do 
-        read -p "$SPEC is '$VAL', correct? (Y/N) " correct
+    while [[ $correct != [yY] && $correct != [yY][eE][sS] && $correct != [nN] && $correct != [nN][oO] && $correct != "" ]] ; do 
+        read -p "$SPEC is '$VAL', correct? (Y/n) " correct
     done
     if [[ $correct == [nN] || $correct == [nN][oO] ]] ; then
         read -p "Set $SPEC to: " newval

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -490,7 +490,6 @@ case $action in
             PAYLOAD="{
             \"device_id\": \"$UUID\",
             \"platform\": \"$PLATFORM\",
-            \"cloud_provider\": \"$CLOUD_PROVIDER\",
             \"cpus\": \"$NUMCPUS\",
             \"cores_per_cpu\": \"$NUMCORESPERCPU\",
             \"cpu_name\": \"$CPUMODEL\",
@@ -499,10 +498,7 @@ case $action in
             \"disk\": [$(echo "$DISKSJSON" |sed 's/,$//g')], 
             \"gpu\": [$(echo "$GPUSJSON" |sed 's/,$//g')], 
             \"instance_type\": \"$INSTANCE_TYPE\",
-            \"min\": \"$(get_carbon_for_load 0)\",
-            \"half\": \"$(get_carbon_for_load 50)\",
-            \"max\": \"$(get_carbon_for_load 100)\",
-            \"current\": \"$(get_carbon_for_load $percentage_15min)\",
+            \"current_load\": \"$percentage_15min\",
             \"location\": \"$LOCATION\"
             }
             "

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,9 @@ Rails.application.routes.draw do
   get "/leaderboard",              to: "report#index"
   post "/add-record",              to: "report#add_record"
 
-  get "/show-devices",             to: "device#show"
+  get "/show-devices",             to: "device#index"
   get "/leaderboard/raw-data",     to: "device#raw_data"
+  get "/devices/:device",          to: "device#show"
   post "/add-tag/:device",         to: "device#add_tag"
   post "/delete-tag/:device",      to: "device#delete_tag"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   get "/show-devices",             to: "device#index"
   get "/leaderboard/raw-data",     to: "device#raw_data"
-  get "/devices/:device",          to: "device#show"
+  get "/device/:device",           to: "device#show"
   post "/add-tag/:device",         to: "device#add_tag"
   post "/delete-tag/:device",      to: "device#delete_tag"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { sessions: "users/sessions" }
+  devise_for :users, controllers: { sessions: "users/sessions", registrations: "users/registrations" }
   root "home#index"
 
   get "/leaderboard",              to: "report#index"

--- a/db/migrate/20240423175345_add_display_name_to_devices.rb
+++ b/db/migrate/20240423175345_add_display_name_to_devices.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToDevices < ActiveRecord::Migration[7.1]
+  def change
+    add_column :devices, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_23_111652) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_23_175345) do
   create_table "devices", id: false, force: :cascade do |t|
     t.string "uuid"
     t.integer "user_id"
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_23_111652) do
     t.text "gpus"
     t.string "cloud_provider"
     t.string "instance_type"
+    t.string "display_name"
     t.index ["user_id"], name: "index_devices_on_user_id"
   end
 

--- a/lib/boavizta.rb
+++ b/lib/boavizta.rb
@@ -1,6 +1,8 @@
 class Boavizta
   require 'faraday'
-  BOAVIZTA_URL="https://api.boavizta.openflighthpc.org"
+  BOAVIZTA_URL='https://api.boavizta.openflighthpc.org'
+  PROVIDERS={'AWS' => 'aws',
+             'OpenStack' => 'alces'}
 
   def self.boavizta
     @boavizta ||= Faraday.new(BOAVIZTA_URL)
@@ -49,5 +51,9 @@ class Boavizta
       end
     end
     JSON.parse(response.body).dig(*%w[impacts gwp use value])
+  end
+
+  def self.provider(platform)
+    PROVIDERS[platform]
   end
 end

--- a/lib/boavizta.rb
+++ b/lib/boavizta.rb
@@ -1,0 +1,42 @@
+class Boavizta
+  BOAVIZTA_URL="https://api.boavizta.openflighthpc.org"
+
+  def boavizta
+    @boavizta ||= Faraday.new(BOAVIZTA_URL)
+  end
+
+  def carbon_for_load(device, cpu_load)
+    response = boavizta.post('/v1/server/') do |req|
+      req.headers[:content_type] = 'application/json'
+      req.params[:verbose] = false
+      req.params[:criteria] = 'gwp'
+      req.body = JSON.generate(
+        {
+          "model": {
+            "type": "rack"
+          },
+          "configuration": {
+            "cpu": {
+              "units": device.cpus,
+              "core_units": device.cores_per_cpu,
+              "name": device.cpu_name
+            },
+            "ram": [{
+              "units": device.ram_units,
+              "capacity": device.ram_capacity_per_unit
+            }],
+            "disk": device.disks
+          },
+          "usage": {
+            "usage_location": device.location,
+            "hours_use_time": 1,
+            "hours_life_time": 1,
+            "time_workload": cpu_load
+          }
+        }
+      )
+      
+      usage = JSON.parse(response.body).dig(*%w[impacts gwp use value])
+    end
+  end
+end

--- a/lib/boavizta.rb
+++ b/lib/boavizta.rb
@@ -9,7 +9,7 @@ class Boavizta
   end
 
   def self.carbon_for_load(device, cpu_load)
-    if device.cloud_provider.blank? || device.instance_type.blank?
+    if device.instance_type.blank?
       response = boavizta.post('/v1/server/') do |req|
         req.headers[:content_type] = 'application/json'
         req.params[:verbose] = false
@@ -55,5 +55,12 @@ class Boavizta
 
   def self.provider(platform)
     PROVIDERS[platform]
+  end
+
+  def self.type_exists?(type, provider)
+    response = boavizta.get('/v1/cloud/instance/all_instances') do |req|
+      req.params[:provider] = provider
+    end
+    JSON.parse(response.body).include?(type)
   end
 end

--- a/lib/boavizta.rb
+++ b/lib/boavizta.rb
@@ -1,42 +1,53 @@
 class Boavizta
+  require 'faraday'
   BOAVIZTA_URL="https://api.boavizta.openflighthpc.org"
 
-  def boavizta
+  def self.boavizta
     @boavizta ||= Faraday.new(BOAVIZTA_URL)
   end
 
-  def carbon_for_load(device, cpu_load)
-    response = boavizta.post('/v1/server/') do |req|
-      req.headers[:content_type] = 'application/json'
-      req.params[:verbose] = false
-      req.params[:criteria] = 'gwp'
-      req.body = JSON.generate(
-        {
-          "model": {
-            "type": "rack"
-          },
-          "configuration": {
-            "cpu": {
-              "units": device.cpus,
-              "core_units": device.cores_per_cpu,
-              "name": device.cpu_name
+  def self.carbon_for_load(device, cpu_load)
+    if device.cloud_provider.blank? || device.instance_type.blank?
+      response = boavizta.post('/v1/server/') do |req|
+        req.headers[:content_type] = 'application/json'
+        req.params[:verbose] = false
+        req.params[:criteria] = 'gwp'
+        req.body = JSON.pretty_generate(
+          {
+            "model": {
+              "type": "rack"
             },
-            "ram": [{
-              "units": device.ram_units,
-              "capacity": device.ram_capacity_per_unit
-            }],
-            "disk": device.disks
-          },
-          "usage": {
-            "usage_location": device.location,
-            "hours_use_time": 1,
-            "hours_life_time": 1,
-            "time_workload": cpu_load
+            "configuration": {
+              "cpu": {
+                "units": device.cpus,
+                "core_units": device.cores_per_cpu,
+                "name": device.cpu_name
+              },
+              "ram": [{
+                "units": device.ram_units,
+                "capacity": device.ram_capacity_per_unit
+              }],
+              "disk": device.disks
+            },
+            "usage": {
+              "usage_location": device.location,
+              "hours_use_time": 1,
+              "hours_life_time": 1,
+              "time_workload": cpu_load
+            }
           }
-        }
-      )
-      
-      usage = JSON.parse(response.body).dig(*%w[impacts gwp use value])
+        )
+      end
+    else
+      response = boavizta.get('/v1/cloud/instance') do |req|
+        req.headers[:content_type] = 'application/json'
+        req.params[:provider] = device.cloud_provider
+        req.params[:instance_type] = device.instance_type
+        req.params[:verbose] = false
+        req.params['criteria'] = 'gwp'
+        req.params['duration'] = 1
+      end
     end
+    JSON.parse(response.body).dig(*%w[impacts gwp use value])
   end
 end

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,7 +1,7 @@
 class JsonWebToken
   SECRET_KEY = Rails.application.credentials.secret_key_base.to_s
 
-  def self.encode(payload, exp = 24.hours.from_now)
+  def self.encode(payload)
     payload[:exp] = exp.to_i
     JWT.encode(payload, SECRET_KEY)
   end

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -2,7 +2,6 @@ class JsonWebToken
   SECRET_KEY = Rails.application.credentials.secret_key_base.to_s
 
   def self.encode(payload)
-    payload[:exp] = exp.to_i
     JWT.encode(payload, SECRET_KEY)
   end
 


### PR DESCRIPTION
This PR enables the server to make its own requests to Boavizta to determine carbon emissions for devices. This means that the Carbon Client no longer needs to calculate any carbon values itself, or even use Boavizta at all.

### For the carbon client

* The payload fields `min`, `half`, `max`, `current` and `cloud_provider` are no longer required.
* The new field `current_load` IS now required, and is measured as a percentage of maximum CPU load.
* This branch adds some minor changes to the carbon client to ensure it is compatible with the changes, but these are only changes to the sent payload data so the Boavizta requests in the client are still made, they just aren't used. A branch stripping away the Boavizta requests is already in the works alongside this one.

### For the leaderboard sever

* A new `Boavizta` class is added to handle the requests. This is responsible for calculating the values which were previously part of the client payload.
* User auth tokens no longer expire.
* Proper validation is included for relevant fields for devices and reports - this also allows for proper feedback if the payload is missing specific values. There's scope in future for this feedback to be even more specific, e.g. "Your platform is AWS, but the given instance type 't27.medium` is not found for AWS"
* Devices now have auto-generated friendly display names which are to be used as identifiers wherever possible. The device UUID is still the primary key of the table, but the display name is now what will be used to identify devices in the leaderboard, and for routes referencing specific devices.
* Each device now has its own page, similar to the user pages introduced in the previous version. I've made a simple example template demonstrating some of the potential for these pages, which may be seen below, and accessed at `/device/<device display name>`. This would be a suitable place to include e.g. a graph of carbon usage over time.
![image](https://github.com/openflighthpc/carbon-leaderboard/assets/57297493/2e28ed4c-84cf-48cd-82ef-21c390783e46)

### Known issues
* All instances with the platform name "OpenStack" are assumed to be `alces` instances. In future I think this is something best handled by the carbon client - sending `platform` as `Alces Cloud` if the instance is on Alces, and using `OpenStack` otherwise. (The client already used to perform this check, but would only update the old `cloud_provider` field).
* Instance types and providers aren't verified to match - if your payload includes a non-empty `instance_type` then it'll need to be a valid instance type for your cloud platform.
