### PR TITLE
Simplify & Improve Carbon Client

### DIFF
--- a/carbon-client/README.md
+++ b/carbon-client/README.md
@@ -44,7 +44,7 @@ By default the script will print a one-line debug of the system specs when `send
 
 ### Offline Data Collection (Payload File)
 
-The payload file (`carbon-log/payload-${UUID}.json`) is created by a device when it is unable to reach the leaderboard or if the variable `OFFLINE` is set. This payload file can have 1 or more entries for the device. 
+The payload file (`carbon-log/payload-${UUID}.json`) is created by a device when it is unable to reach the leaderboard or if the variable `OFFLINE` is set to `true`. This payload file can have 1 or more entries for the device. 
 
 As the `send` command collects the load average over the last 15 minutes for "live" carbon data, this file can be used to build up many entries over time for a single device in order to get historical estimates of the actual impact of the device at whatever load it has been at. 
 

--- a/carbon-client/README.md
+++ b/carbon-client/README.md
@@ -54,3 +54,6 @@ By default the script will prompt confirmation of the various system specs with 
 
 _Note: Overrides to system specs only happen on a per-run basis so would need to be overridden each time the command is run_
 
+### Tagging Instance 
+
+When adding a device to the leaderboard it may be desired to add some tagging to help group it with similar nodes. To do this, set the environment variable `TAGS` to a comma-separated list of tags.

--- a/carbon-client/README.md
+++ b/carbon-client/README.md
@@ -38,7 +38,7 @@ By default the script will print a one-line debug of the system specs when `send
 
 ### Offline Data Collection (Payload File)
 
-The payload file (`carbon-log/payload-${UUID}.json`) is created by a device when it is unable to reach the leaderboard. This payload file can have 1 or more entries for the device. 
+The payload file (`carbon-log/payload-${UUID}.json`) is created by a device when it is unable to reach the leaderboard or if the variable `OFFLINE` is set. This payload file can have 1 or more entries for the device. 
 
 As the `send` command collects the load average over the last 15 minutes for "live" carbon data, this file can be used to build up many entries over time for a single device in order to get historical estimates of the actual impact of the device at whatever load it has been at. 
 
@@ -56,3 +56,4 @@ If the device is connected to the internet, the script won't even need to be dow
 ```bash
 $ curl -s -L https://github.com/openflighthpc/carbon-leaderboard/raw/main/carbon-client/carbon | COMMAND='send' ACCEPT_DEFAULTS='true' /bin/bash
 ```
+

--- a/carbon-client/README.md
+++ b/carbon-client/README.md
@@ -19,8 +19,14 @@ To send data with the script, download it and run:
 ```bash
 $ bash carbon send
 ```
+Alternatively, the script can be run via cURL as follows:
+```bash
+$ bash -c "$(curl -L -s https://raw.githubusercontent.com/openflighthpc/carbon-leaderboard/dev/carbon-client-improvements/carbon-client/carbon)" carbon send
+```
 
-The above will send system information to the [OpenFlight Carbon Leaderboard](https://leaderboard.openflighthpc.org). If the system is unable to reach the internet then it will create a payload file at `carbon-log/payload-${UUID}.json` which can be manually uploaded to the OpenFlight Carbon Leaderboard. 
+In both circumstances, variables can be set before `bash` to influence how the script executes.
+
+The above examples will send system information to the [OpenFlight Carbon Leaderboard](https://leaderboard.openflighthpc.org). If the system is unable to reach the internet then it will create a payload file at `carbon-log/payload-${UUID}.json` in the current working directory which can be manually uploaded to the OpenFlight Carbon Leaderboard. 
 
 ## Sending Data (Advanced) 
 
@@ -47,13 +53,4 @@ As the `send` command collects the load average over the last 15 minutes for "li
 By default the script will prompt confirmation of the various system specs with the user. To prevent this from happening in the future set the environment variable `ACCEPT_DEFAULTS` to `true`. 
 
 _Note: Overrides to system specs only happen on a per-run basis so would need to be overridden each time the command is run_
-
-### Setting Command
-
-If running the command through a pipe (e.g. `curl` from here to execute with BASH) the sub-command to run will need to be set with the variable `COMMAND`. 
-
-If the device is connected to the internet, the script won't even need to be downloaded and can be executed via curl as follows (note that `ACCEPT_DEFAULTS` also needs to be set because interactive prompts don't play nicely with curl):
-```bash
-$ curl -s -L https://github.com/openflighthpc/carbon-leaderboard/raw/main/carbon-client/carbon | COMMAND='send' ACCEPT_DEFAULTS='true' /bin/bash
-```
 

--- a/carbon-client/README.md
+++ b/carbon-client/README.md
@@ -20,7 +20,7 @@ To send data with the script, download it and run:
 $ bash carbon send
 ```
 
-The above will send carbon information to the [OpenFlight Carbon Leaderboard](https://leaderboard.openflighthpc.org). If the system is unable to reach the internet then it will create a payload file at `carbon-log/payload-${UUID}.json` which can be manually uploaded to the OpenFlight Carbon Leaderboard. 
+The above will send system information to the [OpenFlight Carbon Leaderboard](https://leaderboard.openflighthpc.org). If the system is unable to reach the internet then it will create a payload file at `carbon-log/payload-${UUID}.json` which can be manually uploaded to the OpenFlight Carbon Leaderboard. 
 
 ## Sending Data (Advanced) 
 
@@ -47,3 +47,12 @@ As the `send` command collects the load average over the last 15 minutes for "li
 By default the script will prompt confirmation of the various system specs with the user. To prevent this from happening in the future set the environment variable `ACCEPT_DEFAULTS` to `true`. 
 
 _Note: Overrides to system specs only happen on a per-run basis so would need to be overridden each time the command is run_
+
+### Setting Command
+
+If running the command through a pipe (e.g. `curl` from here to execute with BASH) the sub-command to run will need to be set with the variable `COMMAND`. 
+
+If the device is connected to the internet, the script won't even need to be downloaded and can be executed via curl as follows (note that `ACCEPT_DEFAULTS` also needs to be set because interactive prompts don't play nicely with curl):
+```bash
+$ curl -s -L https://github.com/openflighthpc/carbon-leaderboard/raw/main/carbon-client/carbon | COMMAND='send' ACCEPT_DEFAULTS='true' /bin/bash
+```

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -4,7 +4,7 @@
 # Command Setup 
 #
 
-action=$1
+action=${COMMAND:-$1}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" # Directory this script is in
 LOG_DIR="$DIR/carbon-log"
@@ -23,16 +23,25 @@ cat <<EOF
 
   DESCRIPTION:
 
-    Get carbon emission data for your node.
+    Send system specs to $LEADERBOARD_URL to get carbon emission data for your node.
 
   COMMANDS:
 
-    half    Show carbon emissions for node at 50% load
-    full    Show carbon emissions for node at 100% load
-    min     Show carbon emissions for node at 0% load
-    current Show carbon emissions for node at current load (average from past 15 minutes)
-    report  Show detailed report for all carbon emission data
-    send    Calculate and send carbon data to the carbon leaderboard
+    help    Show this help page
+    send    Identify system specs and send carbon data to the carbon leaderboard
+
+  ENVIRONMENT VARIABLES: 
+    
+    ACCEPT_DEFAULTS     If set to a non-empty string will accept the system specs as 
+                        determined by the script
+    AUTH_TOKEN          Defines the authentication token (from $LEADERBOARD_URL) to use
+                        for device ownership
+    COMMAND             If set, will prevent the need for a sub-command to be specified 
+                        (this is useful for running via curl & pipe from upstream) 
+    LOCATION            Specify the 3 digit country code for the device location
+    QUIET               If set to a non-empty string, will prevent debug output of 
+                        system specs before sending (interactive prompt will still
+                        occur unless ACCEPT_DEFAULTS is set) 
 
 EOF
 exit 0
@@ -465,27 +474,6 @@ fi
 #
 
 case $action in
-    "min")
-        echo $(get_carbon_for_load 0)
-        ;;
-    "half")
-        echo $(get_carbon_for_load 50)
-        ;;
-    "full")
-        echo $(get_carbon_for_load 100)
-        ;;
-    "current")
-        echo $(get_carbon_for_load $percentage_15min)
-        ;;
-    "platform")
-        echo $CLOUD_PROVIDER
-        ;;
-    "instance-type")
-        echo $INSTANCE_TYPE
-        ;;
-    "report")
-        report
-        ;;
     "send")
         debug_specs
         PAYLOAD="{

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -250,16 +250,13 @@ fi
 
 case "$PLATFORM" in
     "AWS")
-      CLOUD_PROVIDER=aws
       TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
       INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s --fail http://169.254.169.254/latest/meta-data/instance-type)
       ;;
     "OpenStack")
-      CLOUD_PROVIDER=alces
       INSTANCE_TYPE=$(curl -s --fail http://169.254.169.254/latest/meta-data/instance-type)
       ;;
     "Azure")
-      CLOUD_PROVIDER=azure
       INSTANCE_TYPE=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text")
       ;;
 esac
@@ -267,19 +264,6 @@ esac
 if [ ! -z $INSTANCE_TYPE ] && [ -z $ACCEPT_DEFAULTS ] ; then
     echo "# Validating Instance Type"
     ask_question INSTANCE_TYPE $INSTANCE_TYPE
-fi
-
-if [ $INTERNET == "true" ] ; then
-    ARCHETYPES=$(curl -s -X 'GET' \
-        "${BOAVIZTA_URL}/v1/cloud/instance/all_instances?provider=${CLOUD_PROVIDER}" \
-        -H 'accept: application/json')
-    if echo $ARCHETYPES | jq -e ".|any(. == \"$INSTANCE_TYPE\")" &> /dev/null ; then
-        USE_INSTANCE_TYPE=true
-    fi
-fi
-
-if [ -z $USE_INSTANCE_TYPE ] && [ "$CLOUD_PROVIDER"=="alces" ] ; then
-    CLOUD_PROVIDER=openstack
 fi
 
 #
@@ -341,7 +325,6 @@ case $action in
         PAYLOAD="{
         \"device_id\": \"$UUID\",
         \"platform\": \"$PLATFORM\",
-        \"cloud_provider\": \"$CLOUD_PROVIDER\",
         \"cpus\": \"$NUMCPUS\",
         \"cores_per_cpu\": \"$NUMCORESPERCPU\",
         \"cpu_name\": \"$CPUMODEL\",

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -111,8 +111,10 @@ esac
 
 # Internet Connection
 SITES="https://www.openflighthpc.org https://alces-flight.com https://rockylinux.org https://example.com" 
-if [[ $OFFLINE == "false" || $OFFLINE == "true" ]] ; then
-    INTERNET=$OFFLINE
+if [[ $OFFLINE == "false" ]] ; then 
+    INTERNET=true
+elif [[ $OFFLINE == "true" ]] ; then
+    INTERNET=false
 else
     for site in $SITES ; do 
         if curl -L -s $site >> /dev/null ; then

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -39,149 +39,11 @@ cat <<EOF
     COMMAND             If set, will prevent the need for a sub-command to be specified 
                         (this is useful for running via curl & pipe from upstream) 
     LOCATION            Specify the 3 digit country code for the device location
-    QUIET               If set to a non-empty string, will prevent debug output of 
-                        system specs before sending (interactive prompt will still
-                        occur unless ACCEPT_DEFAULTS is set) 
+    QUIET               If set to a non-empty string will reduce command verbosity
+                        (interactive prompt will still occur unless ACCEPT_DEFAULTS is set) 
 
 EOF
 exit 0
-}
-
-no_internet_message() { 
-cat << EOF 
-This command has been unable to reach the Internet so is unable to determine estimated 
-carbon impact for your resources. 
-
-To calculate the carbon impact of your resources run the 'carbon send' command and upload the 
-payload to your account at $LEADERBOARD_URL.
-EOF
-}
-
-get_carbon_for_load() {
-#
-# Identify Carbon Impact 
-#
-# - If no internet connection detected, this will
-#   not be performed.
-#
-
-if [ $INTERNET == "true" ] ; then
-if [ -z $USE_INSTANCE_TYPE ] ; then
-
-local REQUEST="{
-  \"model\": {
-    \"type\": \"rack\"
-  },
-  \"configuration\": {
-    \"cpu\": {
-      \"units\": $NUMCPUS,
-      \"core_units\": $NUMCORESPERCPU,
-      \"name\": \"$CPUMODEL\"
-    },
-    \"ram\": [{
-      \"units\": $NUMDIMMS,
-      \"capacity\": $GBPERDIMM
-    }],
-    \"disk\": [
-    $(echo "$DISKSJSON" |sed 's/,$//g')
-    ]
-  },
-  \"usage\": {
-    \"usage_location\": \"$LOCATION\",
-    \"hours_use_time\": 1,
-    \"hours_life_time\": 1,
-    \"time_workload\": $1
-  }
-}
-"
-
-local CARBONEQ=$(curl -s -X 'POST' \
-  "${BOAVIZTA_URL}/v1/server/?verbose=false&criteria=gwp" \
-  -H 'accept: application/json' \
-  -H 'Content-Type: application/json' \
-  -d "$REQUEST" |jq '.impacts.gwp.use.value')
-
-else
-
-local REQUEST="{
-\"provider\": \"$CLOUD_PROVIDER\",
-\"instance_type\": \"$INSTANCE_TYPE\",
-\"usage\" : {
-  \"usage_location\": \"GBR\",
-  \"hours_use_time\": 1,
-  \"hours_life_time\": 1,
-  \"time_workload\": [{
-    \"time_percentage\": 100,
-    \"load_percentage\": $1
-    }]
-  }
-}
-"
-
-local CARBONEQ="$(curl -s -X 'POST' \
-  "${BOAVIZTA_URL}/v1/cloud/instance?verbose=false&criteria=gwp" \
-  -H 'accept: application/json' \
-  -H 'Content-Type: application/json' \
-  -d "$REQUEST" |jq '.impacts.gwp.use.value')"
-
-fi
-
-echo $CARBONEQ
-else
-no_internet_message
-fi
-}
-
-
-report() { 
-cat << EOF > $LOG_DIR/report.md
-## Estimated System Specs
-
-CPU: $NUMCPUS x $CPUMODEL ($NUMCORESPERCPU core(s) per CPU)
-
-RAM: $NUMDIMMS x ${GBPERDIMM}GB
-
-Disks: $(echo "$DISKSINFO" |sed 's/, $//g')
-
-GPUs: $(echo "$GPUSINFO" |sed 's/, $//g')
-
-## Platform & Power Information
-
-Platform: $CLOUD_PROVIDER
-
-Location: $LOCATION
-
-EOF
-
-  if [ -z $USE_INSTANCE_TYPE ] ; then
-cat << EOF >> $LOG_DIR/report.md
-## Estimated Carbon Consumption (From Specs)
-EOF
-  else
-cat << EOF >> $LOG_DIR/report.md
-## Estimated Carbon Consumption (From Instance Type)
-### Detected instance type is '${INSTANCE_TYPE}' on ${CLOUD_PROVIDER}
-EOF
-  fi
-
-if [ $INTERNET == "true" ] ; then
-cat << EOF >> $LOG_DIR/report.md
-No Load: $(get_carbon_for_load 0)kgCO2eq/hr
-
-Half Load: $(get_carbon_for_load 50)kgCO2eq/hr
-
-Full Load: $(get_carbon_for_load 100)kgCO2eq/hr
-
-Current Load: $(get_carbon_for_load $percentage_15min)kgCO2eq/hr
-(Current load is based on average load from the last 15 minutes of use)
-EOF
-else
-cat << EOF >> $LOG_DIR/report.md
-$(no_internet_message)
-EOF
-fi
-
-  cat $LOG_DIR/report.md
 }
 
 ask_question() {
@@ -509,7 +371,11 @@ case $action in
         else
             PAYLOAD_FILE="$DIR/payload-$UUID.json"
             echo "$PAYLOAD" >> $PAYLOAD_FILE
-            echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."
+            if [ -z $QUIET ] ; then
+                echo "This command has been unable to reach the Internet so is unable to send system specs to the
+    carbon leaderboard."
+                echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."
+            fi
         fi
         ;; 
     *)

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -236,9 +236,11 @@ done
 # - If internet connection then JQ portable binary can be downloaded if needed 
 if [ $INTERNET == "true" ] ; then
     if ! command -v jq &> /dev/null ; then 
-        curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 > $DIR/jq
-        chmod +x $DIR/jq
-        PATH="$PATH:$DIR"
+        TMP_BIN_PATH="/tmp/carbon-bin"
+        mkdir -p $TMP_BIN_PATH
+        curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 > $TMP_BIN_PATH/jq
+        chmod +x $TMP_BIN_PATH/jq
+        PATH="$PATH:$TMP_BIN_PATH"
         JQ_DL=true
     fi
 fi
@@ -544,5 +546,5 @@ esac
 
 # Tidy JQ if installed by script
 if [ ! -z $JQ_DL ] ; then
-    rm -f $DIR/jq
+    rm -rf $TMP_BIN_PATH
 fi

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -488,22 +488,24 @@ case $action in
         ;;
     "send")
         debug_specs
+        PAYLOAD="{
+        \"device_id\": \"$UUID\",
+        \"platform\": \"$PLATFORM\",
+        \"cloud_provider\": \"$CLOUD_PROVIDER\",
+        \"cpus\": \"$NUMCPUS\",
+        \"cores_per_cpu\": \"$NUMCORESPERCPU\",
+        \"cpu_name\": \"$CPUMODEL\",
+        \"ram_units\": \"$NUMDIMMS\",
+        \"ram_capacity_per_unit\": \"$GBPERDIMM\",
+        \"disk\": [$(echo "$DISKSJSON" |sed 's/,$//g')], 
+        \"gpu\": [$(echo "$GPUSJSON" |sed 's/,$//g')], 
+        \"instance_type\": \"$INSTANCE_TYPE\",
+        \"current_load\": \"$percentage_15min\",
+        \"location\": \"$LOCATION\",
+        \"timestamp\": \"$(date)\"
+        }
+        "
         if [ $INTERNET == "true" ] ; then 
-            PAYLOAD="{
-            \"device_id\": \"$UUID\",
-            \"platform\": \"$PLATFORM\",
-            \"cpus\": \"$NUMCPUS\",
-            \"cores_per_cpu\": \"$NUMCORESPERCPU\",
-            \"cpu_name\": \"$CPUMODEL\",
-            \"ram_units\": \"$NUMDIMMS\",
-            \"ram_capacity_per_unit\": \"$GBPERDIMM\",
-            \"disk\": [$(echo "$DISKSJSON" |sed 's/,$//g')], 
-            \"gpu\": [$(echo "$GPUSJSON" |sed 's/,$//g')], 
-            \"instance_type\": \"$INSTANCE_TYPE\",
-            \"current_load\": \"$percentage_15min\",
-            \"location\": \"$LOCATION\"
-            }
-            "
             RESPONSE=$(curl -s -X 'POST' \
             "${LEADERBOARD_URL}/add-record" \
             -H 'accept: application/json' \
@@ -517,23 +519,6 @@ case $action in
                 echo $RESPONSE
             fi
         else
-            PAYLOAD="{
-            \"device_id\": \"$UUID\",
-            \"platform\": \"$PLATFORM\",
-            \"cloud_provider\": \"$CLOUD_PROVIDER\",
-            \"cpus\": \"$NUMCPUS\",
-            \"cores_per_cpu\": \"$NUMCORESPERCPU\",
-            \"cpu_name\": \"$CPUMODEL\",
-            \"ram_units\": \"$NUMDIMMS\",
-            \"ram_capacity_per_unit\": \"$GBPERDIMM\",
-            \"disk\": [$(echo "$DISKSJSON" |sed 's/,$//g')], 
-            \"gpu\": [$(echo "$GPUSJSON" |sed 's/,$//g')], 
-            \"instance_type\": \"$INSTANCE_TYPE\",
-            \"current_load\": \"$percentage_15min\",
-            \"location\": \"$LOCATION\",
-            \"timestamp\": \"$(date)\"
-            },
-            "
             PAYLOAD_FILE="$DIR/payload-$UUID.json"
             echo "$PAYLOAD" >> $PAYLOAD_FILE
             echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -39,6 +39,9 @@ cat <<EOF
     COMMAND             If set, will prevent the need for a sub-command to be specified 
                         (this is useful for running via curl & pipe from upstream) 
     LOCATION            Specify the 3 digit country code for the device location
+    NUMDIMMS            Specify the number of DIMMs in the system. This option is available
+                        for use cases without sudo/root as insufficient privilege prevents 
+                        correctly determining this information
     OFFLINE             If set this will force the command to run in offline mode (payload
                         will be written to file instead of pushed to leaderboard)
     QUIET               If set to a non-empty string will reduce command verbosity
@@ -158,12 +161,31 @@ if [ -z $ACCEPT_DEFAULTS ] ; then
 fi
 
 # Memory
-NUMDIMMS=$((grep dimm <(ls /sys/devices/system/edac/mc/mc*/ 2> /dev/null ) || echo 'virtual') |wc -l) # This might not be useful at all on systems without ECC memory, further testing needed
+if [ ! -z $NUMDIMMS ] ; then 
+    # If provided env var is a number then it will be trusted 
+    if [ -z $ACCEPT_DEFAULTS ] ; then 
+        while [[ ! $NUMDIMMS =~ ^[0-9]+$ ]] ; do
+            echo "Invalid NUMDIMMS environment varialbe. Expected number, got '$NUMDIMMS'"
+            ask_question NUMDIMMS $NUMDIMMS number
+        done
+    elif [[ ! $NUMDIMMS =~ ^[0-9]+$ ]] ; then
+        echo "Invalid NUMDIMMS environment varialbe. Expected number, got '$NUMDIMMS'"
+        exit 1
+    fi
+elif sudo -l -n sudo &>/dev/null ; then
+    # If sudo, we can use DMI Decode and get correct result
+    NUMDIMMS=$(sudo dmidecode -t memory |grep '^[[:blank:]]*Size:' |grep -v 'No Module Installed'  |wc -l)
+else
+    # This doesn't seem to work on older OSes or those without ECC memory but in the event that these dirs exist then a non-root
+    # user can count the dimms
+    NUMDIMMS=$((grep dimm <(ls /sys/devices/system/edac/mc/mc*/ 2> /dev/null ) || echo 'virtual') |wc -l)
+fi
 GBPERDIMM="$(($(lshw -quiet -c memory 2>/dev/null |grep -A 5 '*-memory' |grep size |grep -o '[[:digit:]]*') / $NUMDIMMS))"
 
 if [ -z $ACCEPT_DEFAULTS ] ; then
     echo "# Validating RAM Specs"
     ask_question NUMDIMMS $NUMDIMMS number
+    GBPERDIMM="$(($(lshw -quiet -c memory 2>/dev/null |grep -A 5 '*-memory' |grep size |grep -o '[[:digit:]]*') / $NUMDIMMS))"
     ask_question GBPERDIMM ${GBPERDIMM}GB number
 fi
 

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -118,7 +118,9 @@ for cmd in $COMMANDS ; do
 done
 
 # Log Directory
-mkdir -p $LOG_DIR
+if [[ $INTERNET == "false" ]] ; then 
+    mkdir -p $LOG_DIR
+fi
 
 #
 # Identify System Info
@@ -311,21 +313,20 @@ case $action in
     "send")
         debug_specs
         PAYLOAD="{
-        \"device_id\": \"$UUID\",
-        \"platform\": \"$PLATFORM\",
-        \"cpus\": \"$NUMCPUS\",
-        \"cores_per_cpu\": \"$NUMCORESPERCPU\",
-        \"cpu_name\": \"$CPUMODEL\",
-        \"ram_units\": \"$NUMDIMMS\",
-        \"ram_capacity_per_unit\": \"$GBPERDIMM\",
-        \"disk\": [$(echo "$DISKSJSON" |sed 's/,$//g')], 
-        \"gpu\": [$(echo "$GPUSJSON" |sed 's/,$//g')], 
-        \"instance_type\": \"$INSTANCE_TYPE\",
-        \"current_load\": \"$percentage_15min\",
-        \"location\": \"$LOCATION\",
-        \"timestamp\": \"$(date)\"
-        }
-        "
+    \"device_id\": \"$UUID\",
+    \"platform\": \"$PLATFORM\",
+    \"cpus\": \"$NUMCPUS\",
+    \"cores_per_cpu\": \"$NUMCORESPERCPU\",
+    \"cpu_name\": \"$CPUMODEL\",
+    \"ram_units\": \"$NUMDIMMS\",
+    \"ram_capacity_per_unit\": \"$GBPERDIMM\",
+    \"disk\": [$(echo "$DISKSJSON" |sed 's/,$//g')], 
+    \"gpu\": [$(echo "$GPUSJSON" |sed 's/,$//g')], 
+    \"instance_type\": \"$INSTANCE_TYPE\",
+    \"current_load\": \"$percentage_15min\",
+    \"location\": \"$LOCATION\",
+    \"timestamp\": \"$(date)\"
+},"
         if [ $INTERNET == "true" ] ; then 
             RESPONSE=$(curl -s -X 'POST' \
             "${LEADERBOARD_URL}/add-record" \
@@ -340,7 +341,7 @@ case $action in
                 echo $RESPONSE
             fi
         else
-            PAYLOAD_FILE="$DIR/payload-$UUID.json"
+            PAYLOAD_FILE="$LOG_DIR/payload-$UUID.json"
             echo "$PAYLOAD" >> $PAYLOAD_FILE
             if [ -z $QUIET ] ; then
                 echo "This command has been set to offline mode or has been unable to reach the Internet"

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -285,24 +285,20 @@ if [ $INTERNET == "true" ] && [ -z $LOCATION ] ; then
         echo "# Validating Location"
         ask_question LOCATION $LOCATION
         while ! echo "$VALID_LOCATIONS" |grep -q -w "$LOCATION" ; do
-            echo "Location not provided or invalid. Must be a 3 letter country code as per the ISO 3166-1 alpha-3 standard."
-            echo "The script failed to identify location correctly due to an issue (e.g. no internet connection) and"
-            echo "the environment variable LOCATION is invalid or has not been provided."
-            echo
-            echo "Valid locations are:"
-            echo "    $VALID_LOCATIONS"
+            echo "Location is invalid. Must be a 3 letter country code as per the ISO 3166-1 alpha-3 standard."
             echo
             ask_question LOCATION $LOCATION
         done
     fi
+elif [ -z $ACCEPT_DEFAULTS ] ; then
+    while ! echo "$VALID_LOCATIONS" |grep -q -w "$LOCATION" ; do
+        echo "Location is invalid. Must be a 3 letter country code as per the ISO 3166-1 alpha-3 standard."
+        echo
+        ask_question LOCATION $LOCATION
+    done
 else 
     if ! echo "$VALID_LOCATIONS" |grep -q -w "$LOCATION" ; then
-        echo "Location not provided or invalid. Must be a 3 letter country code as per the ISO 3166-1 alpha-3 standard."
-        echo "The script failed to identify location correctly due to an issue (e.g. no internet connection) and"
-        echo "the environment variable LOCATION is invalid or has not been provided."
-        echo
-        echo "Valid locations are:"
-        echo "    $VALID_LOCATIONS"
+        echo "Location is invalid. Must be a 3 letter country code as per the ISO 3166-1 alpha-3 standard."
         exit 1
     fi
 fi
@@ -347,8 +343,9 @@ case $action in
             PAYLOAD_FILE="$DIR/payload-$UUID.json"
             echo "$PAYLOAD" >> $PAYLOAD_FILE
             if [ -z $QUIET ] ; then
-                echo "This command has been unable to reach the Internet so is unable to send system specs to the
-    carbon leaderboard."
+                echo "This command has been set to offline mode or has been unable to reach the Internet"
+                echo "so is unable to send system specs to the carbon leaderboard."
+                echo
                 echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."
             fi
         fi

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -102,20 +102,6 @@ for site in $SITES ; do
     fi
 done
 
-# JQ 
-# - If internet connection then JQ is needed (for reporting carbon numbers) 
-# - If internet connection then JQ portable binary can be downloaded if needed 
-if [ $INTERNET == "true" ] ; then
-    if ! command -v jq &> /dev/null ; then 
-        TMP_BIN_PATH="/tmp/carbon-bin"
-        mkdir -p $TMP_BIN_PATH
-        curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 > $TMP_BIN_PATH/jq
-        chmod +x $TMP_BIN_PATH/jq
-        PATH="$PATH:$TMP_BIN_PATH"
-        JQ_DL=true
-    fi
-fi
-
 # Various Commands
 COMMANDS="lshw lsblk md5sum"
 for cmd in $COMMANDS ; do 
@@ -365,8 +351,3 @@ case $action in
         help_message
         ;;
 esac
-
-# Tidy JQ if installed by script
-if [ ! -z $JQ_DL ] ; then
-    rm -rf $TMP_BIN_PATH
-fi

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -39,6 +39,8 @@ cat <<EOF
     COMMAND             If set, will prevent the need for a sub-command to be specified 
                         (this is useful for running via curl & pipe from upstream) 
     LOCATION            Specify the 3 digit country code for the device location
+    OFFLINE             If set this will force the command to run in offline mode (payload
+                        will be written to file instead of pushed to leaderboard)
     QUIET               If set to a non-empty string will reduce command verbosity
                         (interactive prompt will still occur unless ACCEPT_DEFAULTS is set) 
 
@@ -93,14 +95,18 @@ esac
 
 # Internet Connection
 SITES="https://www.openflighthpc.org https://alces-flight.com https://rockylinux.org https://example.com" 
-for site in $SITES ; do 
-    if curl -L -s $site >> /dev/null ; then
-        INTERNET=true
-        break
-    else
-        INTERNET=false
-    fi
-done
+if [ -z $OFFLINE ] ; then
+    for site in $SITES ; do 
+        if curl -L -s $site >> /dev/null ; then
+            INTERNET=true
+            break
+        else
+            INTERNET=false
+        fi
+    done
+else
+    INTERNET=false
+fi
 
 # Various Commands
 COMMANDS="lshw lsblk md5sum"

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -284,7 +284,7 @@ if [ $INTERNET == "true" ] && [ -z $LOCATION ] ; then
     if [ -z $ACCEPT_DEFAULTS ] ; then
         echo "# Validating Location"
         ask_question LOCATION $LOCATION
-        if ! echo "$VALID_LOCATIONS" |grep -q -w "$LOCATION" ; then
+        while ! echo "$VALID_LOCATIONS" |grep -q -w "$LOCATION" ; do
             echo "Location not provided or invalid. Must be a 3 letter country code as per the ISO 3166-1 alpha-3 standard."
             echo "The script failed to identify location correctly due to an issue (e.g. no internet connection) and"
             echo "the environment variable LOCATION is invalid or has not been provided."
@@ -293,7 +293,7 @@ if [ $INTERNET == "true" ] && [ -z $LOCATION ] ; then
             echo "    $VALID_LOCATIONS"
             echo
             ask_question LOCATION $LOCATION
-        fi
+        done
     fi
 else 
     if ! echo "$VALID_LOCATIONS" |grep -q -w "$LOCATION" ; then

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -326,7 +326,7 @@ case $action in
     \"current_load\": \"$percentage_15min\",
     \"location\": \"$LOCATION\",
     \"timestamp\": \"$(date)\"
-},"
+}"
         if [ $INTERNET == "true" ] ; then 
             RESPONSE=$(curl -s -X 'POST' \
             "${LEADERBOARD_URL}/add-record" \
@@ -342,7 +342,7 @@ case $action in
             fi
         else
             PAYLOAD_FILE="$LOG_DIR/payload-$UUID.json"
-            echo "$PAYLOAD" >> $PAYLOAD_FILE
+            echo "$PAYLOAD," >> $PAYLOAD_FILE
             if [ -z $QUIET ] ; then
                 echo "This command has been set to offline mode or has been unable to reach the Internet"
                 echo "so is unable to send system specs to the carbon leaderboard."

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -92,7 +92,7 @@ write_payload() {
         echo "This command has been set to offline mode or has been unable to reach the Internet"
         echo "so is unable to send system specs to the carbon leaderboard."
         echo
-        echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."
+        echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL/data-entry to get your carbon calculations."
     fi
 }
 

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -293,7 +293,7 @@ case "$PLATFORM" in
       ;;
 esac
 
-if [ ! -z $INSTANCE_TYPE ] && [ -z $ACCEPT_DEFAULTS ] ; then
+if [[ ! -z $INSTANCE_TYPE && -z $ACCEPT_DEFAULTS ]] ; then
     echo "# Validating Instance Type"
     ask_question INSTANCE_TYPE $INSTANCE_TYPE
 fi

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -42,8 +42,10 @@ cat <<EOF
     NUMDIMMS            Specify the number of DIMMs in the system. This option is available
                         for use cases without sudo/root as insufficient privilege prevents 
                         correctly determining this information
-    OFFLINE             If set this will force the command to run in offline mode (payload
-                        will be written to file instead of pushed to leaderboard)
+    OFFLINE             If set to true this will force the command to run in offline mode
+                        (payload will be written to file instead of pushed to leaderboard).
+                        If set to false will force the command to run in online mode
+                        (it won't check it can reach the internet and will proceed anyway).
     QUIET               If set to a non-empty string will reduce command verbosity
                         (interactive prompt will still occur unless ACCEPT_DEFAULTS is set) 
 
@@ -82,6 +84,17 @@ debug_specs() {
     fi
 }
 
+write_payload() { 
+    PAYLOAD_FILE="$LOG_DIR/payload-$UUID.json"
+    echo "$PAYLOAD," >> $PAYLOAD_FILE
+    if [ -z $QUIET ] ; then
+        echo "This command has been set to offline mode or has been unable to reach the Internet"
+        echo "so is unable to send system specs to the carbon leaderboard."
+        echo
+        echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."
+    fi
+}
+
 #
 # Runtime Checks
 #
@@ -98,7 +111,9 @@ esac
 
 # Internet Connection
 SITES="https://www.openflighthpc.org https://alces-flight.com https://rockylinux.org https://example.com" 
-if [ -z $OFFLINE ] ; then
+if [[ $OFFLINE == "false" || $OFFLINE == "true" ]] ; then
+    INTERNET=$OFFLINE
+else
     for site in $SITES ; do 
         if curl -L -s $site >> /dev/null ; then
             INTERNET=true
@@ -107,8 +122,6 @@ if [ -z $OFFLINE ] ; then
             INTERNET=false
         fi
     done
-else
-    INTERNET=false
 fi
 
 # Various Commands
@@ -358,19 +371,13 @@ case $action in
             -d "$PAYLOAD")
 
             if [ -z "$RESPONSE" ] ; then
-                echo "Could not reach leaderboard server"
+                echo "Failed to reach leaderboard server"
+                write_payload
             else
                 echo $RESPONSE
             fi
         else
-            PAYLOAD_FILE="$LOG_DIR/payload-$UUID.json"
-            echo "$PAYLOAD," >> $PAYLOAD_FILE
-            if [ -z $QUIET ] ; then
-                echo "This command has been set to offline mode or has been unable to reach the Internet"
-                echo "so is unable to send system specs to the carbon leaderboard."
-                echo
-                echo "Upload $PAYLOAD_FILE to $LEADERBOARD_URL to get your carbon calculations."
-            fi
+            write_payload
         fi
         ;; 
     *)

--- a/carbon-client/carbon
+++ b/carbon-client/carbon
@@ -48,6 +48,7 @@ cat <<EOF
                         (it won't check it can reach the internet and will proceed anyway).
     QUIET               If set to a non-empty string will reduce command verbosity
                         (interactive prompt will still occur unless ACCEPT_DEFAULTS is set) 
+    TAGS                A comma-separated list of tags to assign to the device
 
 EOF
 exit 0
@@ -362,6 +363,7 @@ case $action in
     \"instance_type\": \"$INSTANCE_TYPE\",
     \"current_load\": \"$percentage_15min\",
     \"location\": \"$LOCATION\",
+    \"tags\": [$(echo "$TAGS" |sed 's/^/\\"/g;s/,/\\",\\"/g;s/$/\\"/g')],
     \"timestamp\": \"$(date)\"
 }"
         if [ $INTERNET == "true" ] ; then 


### PR DESCRIPTION
This PR aims to improve the simplicity of the carbon client script and improve on the usage and documentation.

- Corrects documentation to show that script is sending system info, not carbon data, to the leaderboard 
- Removes unnecessary/hangover parts of the program (reporting info on the CLI) so the script is only a companion to the leaderboard
- Add variable for specifying the command to run (to support running via `curl`) 
- Document all the variables in the help output of the script 
- Adds the ability to force offline mode 
- Improves handling of LOCATION in various scenarios (offline mode, interactive/non-interactive, etc)  