### PR TITLE
Dev/data entry page

### DIFF
--- a/app/assets/images/ico/plus.svg
+++ b/app/assets/images/ico/plus.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30.734659mm"
+   height="30.735247mm"
+   viewBox="0 0 30.734659 30.735247"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   inkscape:version="1.2.2 (b0a8486, 2022-12-01)"
+   sodipodi:docname="plus.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview7"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.6819304"
+     inkscape:cx="112.0736"
+     inkscape:cy="221.47171"
+     inkscape:window-width="1850"
+     inkscape:window-height="1136"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" /><defs
+     id="defs2" /><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-5.9614168)"><rect
+       style="fill:#2794d8;stroke-width:1.67466;stroke-linejoin:round;stop-color:#000000"
+       id="rect234"
+       width="8.0324154"
+       height="30.735247"
+       x="17.312534"
+       y="0"
+       ry="4.0162077" /><rect
+       style="fill:#2794d8;stroke-width:1.67466;stroke-linejoin:round;stop-color:#000000"
+       id="rect234-3"
+       width="8.0324154"
+       height="30.735247"
+       x="11.505254"
+       y="-36.584679"
+       ry="4.0162077"
+       transform="rotate(89.585652)" /></g></svg>

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -155,6 +155,11 @@ code {
     margin-bottom: 2rem;
 }
 
+.radio-buttons {
+    width: 10rem;
+    margin-bottom: 3rem;
+}
+
 #dynamic-bg {
     position: fixed;
     top: 0;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -126,6 +126,10 @@ h3 {
     color: var(--color-text);
 }
 
+.wide-card {
+    width: 65%;
+}
+
 a {
     display: block;
     text-decoration: none;
@@ -172,6 +176,7 @@ a {
 
 .big-text {
     font-size: 1.2rem;
+}
 
 .full-width {
     width: 100%;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -146,6 +146,12 @@ code {
 .code-block {
     border: solid 1px rgba(255, 255, 255, 0.7);
     padding: 0.6rem 2rem 0.5rem;
+    overflow-x: scroll;
+}
+
+.code-wrapper {
+    text-align: center;
+    margin-bottom: 2rem;
 }
 
 #dynamic-bg {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -103,6 +103,7 @@ h2 {
 
 h3 {
     font-weight: 700;
+    color: var(--color-text);
 }
 
 .flex-column-centred {
@@ -122,6 +123,7 @@ h3 {
     border: solid 1px var(--color-main);
     border-radius: 0;
     background-color: transparent;
+    color: var(--color-text);
 }
 
 a {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -136,6 +136,17 @@ a {
     color: var(--color-text);
 }
 
+code {
+    color: var(--color-text);
+    background-color: rgba(255, 255, 255, 0.3);
+    padding: 0.3rem;
+}
+
+.code-block {
+    border: solid 1px rgba(255, 255, 255, 0.7);
+    padding: 0.6rem 2rem 0.5rem;
+}
+
 #dynamic-bg {
     position: fixed;
     top: 0;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -127,7 +127,7 @@ h3 {
 }
 
 .wide-card {
-    width: 65%;
+    width: 90%;
 }
 
 a {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -205,3 +205,74 @@ code {
 .full-width {
     width: 100%;
 }
+
+.button {
+    padding-inline: 1.4rem;
+    border-radius:  1.4rem;
+    border: 1px solid var(--color-main);
+    height: 2.2rem;
+    line-height: calc(2rem + 1px);
+    color: var(--color-main);
+    font-weight: 400;
+    background-color: #40404000;
+    filter: drop-shadow(0px 0px 0px #40404000);
+    cursor: pointer;
+    transition:
+            border 360ms ease-out,
+            color 360ms ease-out,
+            background-color 360ms ease-out,
+            filter 360ms ease-out,
+            transform 360ms ease-out;
+}
+
+.button.big-text {
+    background-color: var(--color-main);
+    color: white;
+    height: 2.8rem;
+    line-height: calc(2.8rem - 3px);
+    padding-inline: 1.8rem;
+    border-radius:  1.8rem;
+}
+
+.button:hover {
+    border: 0 solid #2794d800;
+    color: #fff;
+    background-color: #404040;
+    line-height: calc(2rem + 4px);
+    transform: scale(1.1);
+    filter: drop-shadow(var(--fpx) var(--fpx) calc(3 * var(--fpx)) #404040);
+    user-select: none;
+    transition:
+            border 72ms ease-out,
+            color 72ms ease-out,
+            transform 72ms ease-out,
+            filter 72ms ease-out,
+            background-color 72ms ease-out;
+}
+
+.button:active {
+    transform: scale(1);
+    filter: drop-shadow(0px 0px 0px #40404000);
+    transition: none;
+}
+
+.glaring {
+    overflow: hidden;
+}
+
+.glaring::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -50%;
+    height: 100%;
+    width: 100%;
+    background-image: var(--gradient-row-glare);
+    opacity: 0;
+    transition: opacity 360ms ease-out;
+}
+
+.glaring:hover::before {
+    opacity: 1;
+    transition: opacity 72ms ease-out;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -172,4 +172,7 @@ a {
 
 .big-text {
     font-size: 1.2rem;
+
+.full-width {
+    width: 100%;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -140,6 +140,7 @@ code {
     color: var(--color-text);
     background-color: rgba(255, 255, 255, 0.3);
     padding: 0.3rem;
+    text-wrap: nowrap;
 }
 
 .code-block {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -145,7 +145,6 @@ code {
 
 .code-block {
     display: block;
-    border: solid 1px rgba(255, 255, 255, 0.7);
     padding: 0.6rem 2rem 0.5rem;
     overflow-x: scroll;
 }
@@ -170,16 +169,14 @@ code {
     z-index: -1;
 }
 
-.blurred-frame {
+.blurred-frame, .code-block {
     backdrop-filter: blur(calc(270 * var(--fpx)));
     -webkit-backdrop-filter: blur(calc(270 * var(--fpx)));
 }
-.blurred-frame:not(:hover) {
-    box-shadow: inset 0 0 5px rgba(255, 255, 255, .5);
-}
 
-.white-outline {
+.white-outline, .code-block {
     border: var(--border-white);
+    box-shadow: inset 0 0 5px rgba(255, 255, 255, .5);
 }
 
 .rounded-shape {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -154,11 +154,6 @@ code {
     margin-bottom: 2rem;
 }
 
-.radio-buttons {
-    width: 10rem;
-    margin-bottom: 3rem;
-}
-
 #dynamic-bg {
     position: fixed;
     top: 0;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -144,6 +144,7 @@ code {
 }
 
 .code-block {
+    display: block;
     border: solid 1px rgba(255, 255, 255, 0.7);
     padding: 0.6rem 2rem 0.5rem;
     overflow-x: scroll;

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -1,3 +1,13 @@
+.btn-check:checked + .btn-outline-primary {
+    background-color: var(--color-main);
+}
+.btn-check:not(:checked) + .btn-outline-primary {
+    color: var(--color-main);
+}
+.btn-check + .btn-outline-primary {
+    border-color: var(--color-main) !important;
+}
+
 .step-card {
     margin: 0.5rem 0;
 }

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -1,13 +1,3 @@
-.btn-check:checked + .btn-outline-primary {
-    background-color: var(--color-main);
-}
-.btn-check:not(:checked) + .btn-outline-primary {
-    color: var(--color-main);
-}
-.btn-check + .btn-outline-primary {
-    border-color: var(--color-main) !important;
-}
-
 .step-card {
     margin: 0.5rem 0;
 }
@@ -30,9 +20,10 @@
 }
 
 .step-actions {
-    margin-top: 2rem;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 2rem;
     gap: 1rem;
 }
 

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -42,6 +42,7 @@ hr {
     border: solid 1px rgba(255, 255, 255, 0.7);
     padding: 0.7rem 1.4rem;
     margin-top: 1rem;
+    cursor: pointer;
 }
 
 .big-blue-plus {

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -1,3 +1,10 @@
+.step-card {
+    margin: 0.5rem 0;
+}
+.step-card:last-child {
+    margin-bottom: 3rem;
+}
+
 .step-wrapper {
     display: grid;
     grid-template-columns: 4rem auto;

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -27,6 +27,14 @@
     gap: 1rem;
 }
 
+.below-link {
+    display: inline;
+    color: var(--color-main);
+}
+.below-link:hover {
+    filter: brightness(0.8);
+}
+
 .advanced-card {
     margin-top: 5rem;
     margin-bottom: 3rem;

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -27,13 +27,8 @@
     gap: 1rem;
 }
 
-hr {
-    border: solid 1px var(--color-main);
-    width: 80%;
-    margin: 2rem 0;
-}
-
 .advanced-card {
+    margin-top: 5rem;
     margin-bottom: 3rem;
 }
 

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -1,9 +1,6 @@
 .step-card {
     margin: 0.5rem 0;
 }
-.step-card:last-child {
-    margin-bottom: 3rem;
-}
 
 .step-wrapper {
     display: grid;
@@ -27,4 +24,29 @@
     display: flex;
     justify-content: center;
     gap: 1rem;
+}
+
+hr {
+    border: solid 1px var(--color-main);
+    width: 80%;
+    margin: 2rem 0;
+}
+
+.advanced-card {
+    margin-bottom: 3rem;
+}
+
+.advanced-instruction-wrapper {
+    color: var(--color-text);
+    background-color: rgba(255, 255, 255, 0.3);
+    border: solid 1px rgba(255, 255, 255, 0.7);
+    padding: 0.7rem 1.4rem;
+    margin-top: 1rem;
+}
+
+.big-blue-plus {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-main);
+    margin-right: 1.5rem;
 }

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -39,11 +39,14 @@ hr {
 
 .advanced-instruction-wrapper {
     color: var(--color-text);
-    background-color: rgba(255, 255, 255, 0.3);
-    border: solid 1px rgba(255, 255, 255, 0.7);
     padding: 0.7rem 1.4rem;
     margin-top: 1rem;
     cursor: pointer;
+    transition: background-color 360ms ease-out;
+}
+.advanced-instruction-wrapper:hover {
+    background-color: rgba(255, 255, 255, 0.3);
+    transition: background-color 72ms ease-out;
 }
 
 .big-blue-plus {

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -24,4 +24,7 @@
 
 .step-actions {
     margin-top: 2rem;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
 }

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -1,0 +1,20 @@
+.step-wrapper {
+    display: grid;
+    grid-template-columns: 4rem auto;
+    width: 100%;
+}
+
+.step-number {
+    font-size: 3rem;
+    line-height: 3rem;
+    font-weight: 800;
+    color: var(--color-main);
+}
+
+.step-instructions {
+    margin-top: 1rem;
+}
+
+.step-actions {
+    margin-top: 2rem;
+}

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -47,8 +47,11 @@ hr {
 }
 
 .big-blue-plus {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-main);
+    width: 1rem;
     margin-right: 1.5rem;
+    transition: transform 100ms ease-out;
+}
+
+.advanced-instruction-wrapper[aria-expanded='true'] .big-blue-plus {
+    transform: rotate(45deg);
 }

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -53,3 +53,30 @@ input[type="checkbox"] {
 .submit-button {
     margin-top: 3rem;
 }
+
+.btn-check:checked + .btn-outline-primary,
+.btn-outline-primary:is(:hover, :active) {
+    background-color: var(--color-main);
+}
+.btn-check:not(:checked) + .btn-outline-primary,
+.btn-outline-primary:not(:hover, :active) {
+    color: var(--color-main);
+}
+.btn-outline-primary {
+    border-color: var(--color-main) !important;
+}
+
+.form-control, .form-control:focus {
+    border: solid 1px var(--color-main);
+    background-color: transparent;
+    color: var(--color-main);
+}
+
+.form-control:focus {
+    box-shadow: none;
+}
+
+.file-input {
+    display: flex;
+    gap: 1rem;
+}

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -68,6 +68,9 @@ input[type="checkbox"] {
 
 .form-control, .form-control:focus {
     border: solid 1px var(--color-main);
+    border-radius: 2rem;
+    height: 2.2rem;
+    line-height: calc(1.2rem + 4px);
     background-color: transparent;
     color: var(--color-main);
 }
@@ -77,6 +80,9 @@ input[type="checkbox"] {
 }
 
 .file-input {
-    display: flex;
-    gap: 1rem;
+    max-width: 37rem;
+}
+
+.file-input input[type='file'] {
+    max-width: 30rem;
 }

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -56,7 +56,8 @@ input[type="checkbox"] {
 
 .btn-check:checked + .btn-outline-primary,
 .btn-outline-primary:is(:hover, :active) {
-    background-color: var(--color-main);
+    background-color: var(--color-main) !important;
+    color: white !important;
 }
 .btn-check:not(:checked) + .btn-outline-primary,
 .btn-outline-primary:not(:hover, :active) {
@@ -64,6 +65,7 @@ input[type="checkbox"] {
 }
 .btn-outline-primary {
     border-color: var(--color-main) !important;
+    line-height: calc(1.2rem + 4px) !important;
 }
 
 .form-control, .form-control:focus {

--- a/app/assets/stylesheets/leaderboard.css
+++ b/app/assets/stylesheets/leaderboard.css
@@ -123,6 +123,7 @@
 .leaderboard-item-wrapper:hover {
   background-color: #404040;
   color: #ffffff;
+  box-shadow: none;
   filter: drop-shadow(calc(3 * var(--fpx)) calc(3 * var(--fpx)) calc(6 * var(--fpx)) var(--color-text));
   transform: scale(1.012);
   transition:

--- a/app/assets/stylesheets/navbar.css
+++ b/app/assets/stylesheets/navbar.css
@@ -66,6 +66,7 @@
 }
 
 .nav-link {
+    margin-inline: 2rem;
     font-weight: 450;
     filter: drop-shadow(0px 0px 0px var(--color-text));
     transition:

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -1,0 +1,4 @@
+class DataEntryController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -14,13 +14,17 @@ class DataEntryController < ApplicationController
                                        .chomp(',')
       device = Device.find_by(uuid: data['device_id'])
       if device
-        redirect_to action: index, upload_status: 'Device has already been entered'
+        refresh_page('Device has already been entered')
       else
         device = Device.create_from_json(data)
-        redirect_to action: index, upload_status: device.errors.messages.values.join(', ')
+        refresh_page(device.errors.messages.values.join(', '))
       end
     rescue JSON::ParserError
-      redirect_to action: index, upload_status: 'Invalid JSON file'
+      refresh_page('Invalid JSON file')
     end
+  end
+
+  def refresh_page(upload_status)
+    redirect_to action: index, upload_status: upload_status, anchor: 'step-card-3'
   end
 end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -41,6 +41,6 @@ class DataEntryController < ApplicationController
     redirect_to action: index,
                 upload_status: upload_status,
                 offline_instructions: offline_instructions,
-                anchor: 'step-card-3'
+                anchor: 'anchor-card'
   end
 end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -16,11 +16,20 @@ class DataEntryController < ApplicationController
                  .last
       device = Device.find_by(uuid: json['device_id'])
       if device
-        refresh_page('Device has already been entered')
+        existing = true
       else
+        existing = false
         device = Device.create_from_json(json)
+      end
+      if device.errors.empty?
+        Report.create(device_id: device.uuid,
+                      current: Boavizta.carbon_for_load(device, data['current_load'])
+        )
+        refresh_page("Device #{device.display_name} successfully #{existing ? 'updated' : 'entered'}")
+      else
         refresh_page(device.errors.full_messages.join(', '))
       end
+
     rescue JSON::ParserError
       refresh_page('Invalid payload file format')
     rescue

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -8,15 +8,17 @@ class DataEntryController < ApplicationController
 
   def upload
     begin
-      data = JSON.parse params[:device].read
-                                       .gsub("\n","")
-                                       .strip
-                                       .chomp(',')
-      device = Device.find_by(uuid: data['device_id'])
+      data = params[:device].read
+                            .gsub("\n","")
+                            .strip
+                            .chomp(',')
+      json = JSON.parse("[ #{data} ]")
+                 .last
+      device = Device.find_by(uuid: json['device_id'])
       if device
         refresh_page('Device has already been entered')
       else
-        device = Device.create_from_json(data)
+        device = Device.create_from_json(json)
         refresh_page(device.errors.messages.values.join(', '))
       end
     rescue JSON::ParserError

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -1,4 +1,8 @@
 class DataEntryController < ApplicationController
   def index
   end
+
+  def download_carbon
+    send_file(File.join(Rails.root, 'carbon-client', "carbon"))
+  end
 end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -5,4 +5,12 @@ class DataEntryController < ApplicationController
   def download_carbon
     send_file(File.join(Rails.root, 'carbon-client', "carbon"))
   end
+
+  def upload
+    data = JSON.parse params[:device].read
+                                     .gsub("\n","")
+                                     .strip
+                                     .chomp(',')
+    Device.create_from_json(data)
+  end
 end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -7,10 +7,20 @@ class DataEntryController < ApplicationController
   end
 
   def upload
-    data = JSON.parse params[:device].read
-                                     .gsub("\n","")
-                                     .strip
-                                     .chomp(',')
-    Device.create_from_json(data)
+    begin
+      data = JSON.parse params[:device].read
+                                       .gsub("\n","")
+                                       .strip
+                                       .chomp(',')
+      device = Device.find_by(uuid: data['device_id'])
+      if device
+        redirect_to action: index, upload_status: 'Device has already been entered'
+      else
+        device = Device.create_from_json(data)
+        redirect_to action: index, upload_status: device.errors.messages.values.join(', ')
+      end
+    rescue JSON::ParserError
+      redirect_to action: index, upload_status: 'Invalid JSON file'
+    end
   end
 end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -19,7 +19,7 @@ class DataEntryController < ApplicationController
         refresh_page('Device has already been entered')
       else
         device = Device.create_from_json(json)
-        refresh_page(device.errors.messages.values.join(', '))
+        refresh_page(device.errors.full_messages.join(', '))
       end
     rescue JSON::ParserError
       refresh_page('Invalid payload file format')
@@ -28,7 +28,10 @@ class DataEntryController < ApplicationController
     end
   end
 
-  def refresh_page(upload_status)
-    redirect_to action: index, upload_status: upload_status, anchor: 'step-card-3'
+  def refresh_page(upload_status, offline_instructions = true)
+    redirect_to action: index,
+                upload_status: upload_status,
+                offline_instructions: offline_instructions,
+                anchor: 'step-card-3'
   end
 end

--- a/app/controllers/data_entry_controller.rb
+++ b/app/controllers/data_entry_controller.rb
@@ -22,7 +22,9 @@ class DataEntryController < ApplicationController
         refresh_page(device.errors.messages.values.join(', '))
       end
     rescue JSON::ParserError
-      refresh_page('Invalid JSON file')
+      refresh_page('Invalid payload file format')
+    rescue
+      refresh_page('An unexpected error occurred')
     end
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -39,17 +39,4 @@ class ReportController < ApplicationController
 
     render json: "Report saved successfully: Current carbon usage of #{report.current}kgCO2eq saved for #{@current_user ? @current_user.username : 'an anonymous user'}'s device '#{device.display_name}'"
   end
-
-  def new_name
-    colours = %w(Red Orange Yellow Green Blue Indigo Violet Pink Purple Grey)
-    adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
-    animals = %w(Dog Cat Chicken Duck Otter Lion Tiger Fish Snake Dragon)
-
-    name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
-    while Device.find_by(display_name: name)
-      name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
-    end
-    name
-  end
 end
-

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -19,39 +19,17 @@ class ReportController < ApplicationController
   def add_record
     data = JSON.parse(request.body.read)
     device = Device.find_by(uuid: data['device_id'])
-    if !device
-      device = Device.new(uuid: data['device_id'],
-                          display_name: new_name,
-                          user_id: @current_user&.id,
-                          cpus: data['cpus'],
-                          cores_per_cpu: data['cores_per_cpu'],
-                          cpu_name: data['cpu_name'],
-                          ram_units: data['ram_units'],
-                          ram_capacity_per_unit: data['ram_capacity_per_unit'],
-                          disks: data['disk'] || [],
-                          gpus: data['gpu'] || [],
-                          platform: data['platform'],
-                          location: data['location'],
-                          tags: data['tags'] || []
-                         )
-      if device.valid?
-        device.cloud_provider = Boavizta.provider(device.platform)
-        device.instance_type = data['instance_type'] if Boavizta.type_exists?(data['instance_type'], device.cloud_provider)
-        device.min = Boavizta.carbon_for_load(device, 0)
-        device.half = Boavizta.carbon_for_load(device, 50)
-        device.max = Boavizta.carbon_for_load(device, 100)
-        device.group = device.determine_group
-        device.save
-      else
+
+    unless device
+      device = Device.create_from_json(data, @current_user) unless device
+      if device.errors
         render json: "Error(s) with payload data: #{device.errors.full_messages.join(', ')}"
         return
       end
     end
-
     report = Report.new(device_id: device.uuid,
                         current: Boavizta.carbon_for_load(device, data['current_load'])
                        )
-
     if report.valid?
       report.save
     else

--- a/app/javascript/data_entry/index.js
+++ b/app/javascript/data_entry/index.js
@@ -14,22 +14,26 @@ function noButton() {
 }
 
 function updateInstructions() {
+  let stepNumber = 1;
+  const cards = document.getElementsByClassName('step-card');
   if (yesButton().checked) {
-    const cards = document.getElementsByClassName('step-card');
     for (let i = 0; i < cards.length; i++) {
       let card = cards[i];
       if (card.dataset.online === 'true') {
         card.style.display = 'block';
+        card.getElementsByClassName('step-number')[0].innerHTML = stepNumber;
+        stepNumber++;
       } else {
         card.style.display = 'none';
       }
     }
   } else {
-    const cards = document.getElementsByClassName('step-card');
     for (let i = 0; i < cards.length; i++) {
       let card = cards[i];
       if (card.dataset.offline === 'true') {
         card.style.display = 'block';
+        card.getElementsByClassName('step-number')[0].innerHTML = stepNumber;
+        stepNumber++;
       } else {
         card.style.display = 'none';
       }

--- a/app/javascript/data_entry/index.js
+++ b/app/javascript/data_entry/index.js
@@ -1,0 +1,38 @@
+document.addEventListener("DOMContentLoaded", function(){
+  updateInstructions();
+
+  yesButton().onclick = updateInstructions;
+  noButton().onclick = updateInstructions;
+});
+
+function yesButton() {
+  return document.getElementById('radio-yes');
+}
+
+function noButton() {
+  return document.getElementById('radio-no');
+}
+
+function updateInstructions() {
+  if (yesButton().checked) {
+    const cards = document.getElementsByClassName('step-card');
+    for (let i = 0; i < cards.length; i++) {
+      let card = cards[i];
+      if (card.dataset.online === 'true') {
+        card.style.display = 'block';
+      } else {
+        card.style.display = 'none';
+      }
+    }
+  } else {
+    const cards = document.getElementsByClassName('step-card');
+    for (let i = 0; i < cards.length; i++) {
+      let card = cards[i];
+      if (card.dataset.offline === 'true') {
+        card.style.display = 'block';
+      } else {
+        card.style.display = 'none';
+      }
+    }
+  }
+}

--- a/app/javascript/data_entry/index.js
+++ b/app/javascript/data_entry/index.js
@@ -1,5 +1,6 @@
 document.addEventListener("DOMContentLoaded", function(){
   updateInstructions();
+  setCodeBlockWidth();
 
   yesButton().onclick = updateInstructions;
   noButton().onclick = updateInstructions;
@@ -38,5 +39,14 @@ function updateInstructions() {
         card.style.display = 'none';
       }
     }
+  }
+}
+
+function setCodeBlockWidth() {
+  const codeWrappers = document.querySelectorAll(".step-wrapper .code-block");
+  for (let i = 0; i < codeWrappers.length; i++) {
+    let wrapper = codeWrappers[i];
+    let stepContainer = wrapper.closest("div.step-wrapper");
+    wrapper.style.maxWidth = `${stepContainer.getBoundingClientRect().width - 64}px`;
   }
 }

--- a/app/javascript/data_entry/index.js
+++ b/app/javascript/data_entry/index.js
@@ -40,6 +40,7 @@ function updateInstructions() {
       }
     }
   }
+  setCodeBlockWidth();
 }
 
 function setCodeBlockWidth() {

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -40,12 +40,16 @@ class Device < ApplicationRecord
     end
   end
 
-  def pretty_owner
-    user&.username || "Anonymous"
-  end
+  def self.new_name
+    colours = %w(Red Orange Yellow Green Blue Indigo Violet Pink Purple Grey)
+    adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
+    animals = %w(Dog Cat Chicken Duck Otter Lion Tiger Fish Snake Dragon)
 
-  def two_digit_location
-    ISO3166::Country.find_country_by_alpha3(self.location).alpha2
+    name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
+    while Device.find_by(display_name: name)
+      name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
+    end
+    name
   end
 
   def config_attributes
@@ -64,15 +68,11 @@ class Device < ApplicationRecord
     Device.pluck(:group).compact.max.to_i + 1
   end
 
-  def new_name
-    colours = %w(Red Orange Yellow Green Blue Indigo Violet Pink Purple Grey)
-    adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
-    animals = %w(Dog Cat Chicken Duck Otter Lion Tiger Fish Snake Dragon)
+  def pretty_owner
+    user&.username || "Anonymous"
+  end
 
-    name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
-    while Device.find_by(display_name: name)
-      name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
-    end
-    name
+  def two_digit_location
+    ISO3166::Country.find_country_by_alpha3(self.location).alpha2
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -11,30 +11,33 @@ class Device < ApplicationRecord
             :location, :cpu_name, presence: { message: "is required" }
 
   def self.create_from_json(data, user = nil)
-    device = Device.new(uuid: data['device_id'],
-                        display_name: new_name,
-                        user_id: user&.id,
-                        cpus: data['cpus'],
-                        cores_per_cpu: data['cores_per_cpu'],
-                        cpu_name: data['cpu_name'],
-                        ram_units: data['ram_units'],
-                        ram_capacity_per_unit: data['ram_capacity_per_unit'],
-                        disks: data['disk'] || [],
-                        gpus: data['gpu'] || [],
-                        platform: data['platform'],
-                        location: data['location'],
-                        tags: data['tags'] || []
-    )
-    if device.valid?
-      device.cloud_provider = Boavizta.provider(device.platform)
-      device.instance_type = data['instance_type'] if Boavizta.type_exists?(data['instance_type'], device.cloud_provider)
-      device.min = Boavizta.carbon_for_load(device, 0)
-      device.half = Boavizta.carbon_for_load(device, 50)
-      device.max = Boavizta.carbon_for_load(device, 100)
-      device.group = device.determine_group
-      device.save
+    begin
+      device = Device.new(uuid: data['device_id'],
+                          display_name: new_name,
+                          user_id: user&.id,
+                          cpus: data['cpus'],
+                          cores_per_cpu: data['cores_per_cpu'],
+                          cpu_name: data['cpu_name'],
+                          ram_units: data['ram_units'],
+                          ram_capacity_per_unit: data['ram_capacity_per_unit'],
+                          disks: data['disk'] || [],
+                          gpus: data['gpu'] || [],
+                          platform: data['platform'],
+                          location: data['location'],
+                          tags: data['tags'] || []
+      )
+      if device.valid?
+        device.cloud_provider = Boavizta.provider(device.platform)
+        device.instance_type = data['instance_type'] if Boavizta.type_exists?(data['instance_type'], device.cloud_provider)
+        device.min = Boavizta.carbon_for_load(device, 0)
+        device.half = Boavizta.carbon_for_load(device, 50)
+        device.max = Boavizta.carbon_for_load(device, 100)
+        device.group = device.determine_group
+        device.save
+      end
+    ensure
+      return device
     end
-    device
   end
 
   def pretty_owner
@@ -59,5 +62,17 @@ class Device < ApplicationRecord
       end
     end
     Device.pluck(:group).compact.max.to_i + 1
+  end
+
+  def new_name
+    colours = %w(Red Orange Yellow Green Blue Indigo Violet Pink Purple Grey)
+    adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
+    animals = %w(Dog Cat Chicken Duck Otter Lion Tiger Fish Snake Dragon)
+
+    name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
+    while Device.find_by(display_name: name)
+      name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
+    end
+    name
   end
 end

--- a/app/views/data_entry/_advanced_instruction.html.erb
+++ b/app/views/data_entry/_advanced_instruction.html.erb
@@ -1,14 +1,11 @@
-<div class="advanced-instruction-wrapper">
-  <button class="button"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#<%= locals[:id] %>"
-          aria-expanded="false"
-          aria-controls="<%= locals[:id] %>"
-  >
-    <span class="big-blue-plus">+</span>
-    <span class="big-text"><%= locals[:title] %></span>
-  </button>
+<div class="advanced-instruction-wrapper"
+     data-bs-toggle="collapse"
+     data-bs-target="#<%= locals[:id] %>"
+     aria-expanded="false"
+     aria-controls="<%= locals[:id] %>"
+>
+  <span class="big-blue-plus">+</span>
+  <span class="big-text"><%= locals[:title] %></span>
   <div class="collapse" id="<%= locals[:id] %>">
     <br>
     <%= yield %>

--- a/app/views/data_entry/_advanced_instruction.html.erb
+++ b/app/views/data_entry/_advanced_instruction.html.erb
@@ -1,0 +1,16 @@
+<div class="advanced-instruction-wrapper">
+  <button class="button"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#<%= locals[:id] %>"
+          aria-expanded="false"
+          aria-controls="<%= locals[:id] %>"
+  >
+    <span class="big-blue-plus">+</span>
+    <span class="big-text"><%= locals[:title] %></span>
+  </button>
+  <div class="collapse" id="<%= locals[:id] %>">
+    <br>
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/data_entry/_advanced_instruction.html.erb
+++ b/app/views/data_entry/_advanced_instruction.html.erb
@@ -4,8 +4,10 @@
      aria-expanded="false"
      aria-controls="<%= locals[:id] %>"
 >
-  <span class="big-blue-plus">+</span>
-  <span class="big-text"><%= locals[:title] %></span>
+  <div class="d-flex align-items-center">
+    <img src="assets/ico/plus.svg" class="big-blue-plus">
+    <span class="big-text"><%= locals[:title] %></span>
+  </div>
   <div class="collapse" id="<%= locals[:id] %>">
     <br>
     <%= yield %>

--- a/app/views/data_entry/_advanced_instruction.html.erb
+++ b/app/views/data_entry/_advanced_instruction.html.erb
@@ -1,4 +1,4 @@
-<div class="advanced-instruction-wrapper"
+<div class="advanced-instruction-wrapper blurred-frame white-outline"
      data-bs-toggle="collapse"
      data-bs-target="#<%= locals[:id] %>"
      aria-expanded="false"

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -4,17 +4,11 @@
     <div class="step">
       <h3 class="step-title"><%= locals[:title] %></h3>
       <div class="step-instructions">
-        <p>
-          <%= locals[:instructions] %>
-        </p>
+        <%= yield %>
       </div>
     </div>
   </div>
   <div class="step-actions flex-column-centred">
-    <% if locals[:number] == 1 %>
-      <%= link_to "Sign up", new_registration_path(:user) %>
-    <% elsif locals[:number] == 2 %>
-      <%= link_to "Download", action: :download_carbon %>
-    <% end %>
+    <%= yield :buttons %>
   </div>
 </div>

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card wide-card step-card">
+<div class="card wide-card step-card" id="step-card-<%= locals[:number] %>">
   <div class="step-wrapper">
     <span class="step-number"><%= locals[:number] %></span>
     <div class="step">

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -8,7 +8,7 @@
       </div>
     </div>
   </div>
-  <div class="<%= 'step-actions ' unless locals[:hide_actions] %>flex-column-centred">
+  <div class="<%= 'step-actions ' unless locals[:hide_actions] %>">
     <%= yield :buttons %>
   </div>
 </div>

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card full-width mt-4">
+<div class="card wide-card mt-4">
   <div class="step-wrapper">
     <span class="step-number"><%= locals[:number] %></span>
     <div class="step">

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -14,7 +14,7 @@
     <% if locals[:number] == 1 %>
       <%= link_to "Sign up", new_registration_path(:user) %>
     <% elsif locals[:number] == 2 %>
-      <%= link_to "Download", data_entry_path %>
+      <%= link_to "Download", action: :download_carbon %>
     <% end %>
   </div>
 </div>

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,4 +1,5 @@
 <div class="card wide-card step-card"
+     <%= "id=#{ locals[:id] } " if locals[:id] %>
      data-online="<%= locals[:show_card][:online] %>"
      data-offline="<%= locals[:show_card][:offline] %>"
 >

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card wide-card my-3">
+<div class="card wide-card step-card">
   <div class="step-wrapper">
     <span class="step-number"><%= locals[:number] %></span>
     <div class="step">

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -4,7 +4,7 @@
      data-offline="<%= locals[:show_card][:offline] %>"
 >
   <div class="step-wrapper">
-    <span class="step-number"><%= locals[:number] %></span>
+    <span class="step-number"></span>
     <div class="step">
       <h3 class="step-title"><%= locals[:title] %></h3>
       <div class="step-instructions">

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,5 +1,4 @@
 <div class="card wide-card step-card"
-     id="step-card-<%= locals[:number] %>"
      data-online="<%= locals[:show_card][:online] %>"
      data-offline="<%= locals[:show_card][:offline] %>"
 >

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card wide-card mt-4">
+<div class="card wide-card my-3">
   <div class="step-wrapper">
     <span class="step-number"><%= locals[:number] %></span>
     <div class="step">
@@ -8,7 +8,7 @@
       </div>
     </div>
   </div>
-  <div class="step-actions flex-column-centred">
+  <div class="<%= 'step-actions ' unless locals[:hide_actions] %>flex-column-centred">
     <%= yield :buttons %>
   </div>
 </div>

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,4 +1,8 @@
-<div class="card wide-card step-card" id="step-card-<%= locals[:number] %>">
+<div class="card wide-card step-card"
+     id="step-card-<%= locals[:number] %>"
+     data-online="<%= locals[:show_card][:online] %>"
+     data-offline="<%= locals[:show_card][:offline] %>"
+>
   <div class="step-wrapper">
     <span class="step-number"><%= locals[:number] %></span>
     <div class="step">

--- a/app/views/data_entry/_step_card.html.erb
+++ b/app/views/data_entry/_step_card.html.erb
@@ -1,0 +1,20 @@
+<div class="card full-width mt-4">
+  <div class="step-wrapper">
+    <span class="step-number"><%= locals[:number] %></span>
+    <div class="step">
+      <h3 class="step-title"><%= locals[:title] %></h3>
+      <div class="step-instructions">
+        <p>
+          <%= locals[:instructions] %>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="step-actions flex-column-centred">
+    <% if locals[:number] == 1 %>
+      <%= link_to "Sign up", new_registration_path(:user) %>
+    <% elsif locals[:number] == 2 %>
+      <%= link_to "Download", data_entry_path %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -19,6 +19,28 @@
     <%= link_to "Download", action: :download_carbon %>
   <% end %>
   <p>
-    The Carbon Client is a BASH script which collects the required data for adding entries to the Carbon Leaderboard.
+    The Carbon Client is a BASH script which collects the required data for
+    adding entries to the Carbon Leaderboard.
+  </p>
+<% end %>
+<%= render 'step_card', locals: {
+  number: 3,
+  title: 'Run the Carbon Client on your server',
+  hide_actions: true,
+} do %>
+  <% content_for :buttons, :flush => true do %>
+    <div></div>
+  <% end %>
+  <p>
+    To collect data on your server emissions and enter onto the leaderboard,
+    save the Carbon Client on your server and run the following command:
+  </p>
+  <p class="text-center mb-4">
+    <code class="code-block">bash carbon send</code>
+  </p>
+  <p>
+    This is all you need to run to submit your server data to the leaderboard.
+    However, you can find information below about more advanced options, such
+    as associating your servers with your user account.
   </p>
 <% end %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -17,18 +17,19 @@
   >
   <label class="btn btn-outline-primary button glaring" for="radio-no">No</label>
 </div>
-
-<%= render 'step_card', locals: {
-  title: 'Make an account (optional)',
-  show_card: { online: true, offline: true },
-} do %>
-  <% content_for :buttons, :flush => true do %>
-    <%= link_to "Sign up", new_registration_path(:user), class: 'button glaring' %>
+<% unless user_signed_in? %>
+  <%= render 'step_card', locals: {
+    title: 'Make an account (optional)',
+    show_card: { online: true, offline: true },
+  } do %>
+    <% content_for :buttons, :flush => true do %>
+      <%= link_to "Sign up", new_registration_path(:user), class: 'button glaring' %>
+    <% end %>
+    <p>
+      Make an account to claim your servers on the leaderboard and get
+      access to tools for tracking your server emission stats more easily.
+    </p>
   <% end %>
-  <p>
-    Make an account to claim your servers on the leaderboard and get
-    access to tools for tracking your server emission stats more easily.
-  </p>
 <% end %>
 <%= render 'step_card', locals: {
   title: 'Run the Carbon Client on your server',

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,9 +1,9 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
-<div class="mb-4">
+<div class="mb-4 text-center">
   <p>Is your server connected to the internet?</p>
-  <input type="radio" id="radio-yes" name="age" value="yes">
+  <input type="radio" id="radio-yes" name="internet" value="yes" checked="checked">
   <label for="yes">Yes</label>
-  <input type="radio" id="radio-no" name="age" value="no">
+  <input type="radio" id="radio-no" name="internet" value="no">
   <label for="no">No</label>
 </div>
 

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -19,7 +19,6 @@
 </div>
 
 <%= render 'step_card', locals: {
-  number: 1,
   title: 'Make an account (optional)',
   show_card: { online: true, offline: true },
 } do %>
@@ -32,7 +31,6 @@
   </p>
 <% end %>
 <%= render 'step_card', locals: {
-  number: 2.1,
   title: 'Run the Carbon Client on your server',
   hide_actions: true,
   show_card: { online: true, offline: false },
@@ -57,7 +55,6 @@
 <% end %>
 
 <%= render 'step_card', locals: {
-  number: 2.2,
   title: 'Download the Carbon Client',
   show_card: { online: false, offline: true },
 } do %>
@@ -70,7 +67,6 @@
   </p>
 <% end %>
 <%= render 'step_card', locals: {
-  number: 3,
   title: 'Run the Carbon Client on your server',
   hide_actions: true,
   show_card: { online: false, offline: true },
@@ -92,7 +88,6 @@
   </p>
 <% end %>
 <%= render 'step_card', locals: {
-  number: 4,
   title: 'Upload your data',
   show_card: { online: false, offline: true },
 } do %>
@@ -110,7 +105,6 @@
   </p>
 <% end %>
 <%= render 'step_card', locals: {
-  number: 5,
   title: 'See how your server does on the leaderboard!',
   show_card: { online: true, offline: true },
 } do %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -21,7 +21,31 @@
   </p>
 <% end %>
 <%= render 'step_card', locals: {
-  number: 2,
+  number: 2.1,
+  title: 'Run the Carbon Client on your server',
+  hide_actions: true,
+  show_card: { online: true, offline: false },
+} do %>
+  <% content_for :buttons, :flush => true do %>
+    <div></div>
+  <% end %>
+  <p>
+    To collect data on your server specifications and enter onto the leaderboard,
+    run the following command on your server:
+  </p>
+  <p class="code-wrapper">
+    <code class="code-block">
+      curl -s -L https://github.com/openflighthpc/carbon-leaderboard/raw/main/carbon-client/carbon | COMMAND='send' ACCEPT_DEFAULTS='true' /bin/bash
+    </code>
+  </p>
+  <p>
+    For more options, such as associating your servers with your user account,
+    see the advanced usage information below.
+  </p>
+<% end %>
+
+<%= render 'step_card', locals: {
+  number: 2.2,
   title: 'Download the Carbon Client',
   show_card: { online: false, offline: true },
 } do %>
@@ -50,14 +74,14 @@
     <code class="code-block">bash carbon send</code>
   </p>
   <p>
-    This is all you need to run to submit your server data to the leaderboard.
+    This will collect all the data you need to enter your server onto the leaderboard.
     However, you can find information below about more advanced options, such
     as associating your servers with your user account.
   </p>
 <% end %>
 <%= render 'step_card', locals: {
   number: 4,
-  title: 'Upload your data manually',
+  title: 'Upload your data',
   show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
@@ -74,9 +98,7 @@
     <% end %>
   <% end %>
   <p>
-    If your system has internet access, you can skip this step! Otherwise, the
-    Carbon Client will create a payload file at <code>carbon-log/payload-${UUID}.json</code>
-    which can be manually uploaded to the OpenFlight Carbon Leaderboard.
+    Find your payload file at <code>carbon-log/payload-${UUID}.json</code> and upload it below.
   </p>
 <% end %>
 <%= render 'step_card', locals: {

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,20 +1,21 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
-<div class="mb-4 text-center">
-  <p>Is your server connected to the internet?</p>
+<p class="text-center">Is your server connected to the internet?</p>
+<div class="btn-group radio-buttons flex-space-between" role="group" aria-label="internet-toggle">
   <input type="radio"
+         class="btn-check"
+         name="btnradio"
          id="radio-yes"
-         name="internet"
-         value="yes"
-         <%= 'checked="checked"' unless params[:offline_instructions] %>
+         autocomplete="off"
+         <%= 'checked' unless params[:offline_instructions] %>
   >
-  <label for="yes">Yes</label>
+  <label class="btn btn-outline-primary" for="radio-yes">Yes</label>
   <input type="radio"
-         id="radio-no"
-         name="internet"
-         value="no"
-         <%= 'checked="checked"' if params[:offline_instructions] %>
+         class="btn-check"
+         name="btnradio" id="radio-no"
+         autocomplete="off"
+         <%= 'checked' if params[:offline_instructions] %>
   >
-  <label for="no">No</label>
+  <label class="btn btn-outline-primary" for="radio-no">No</label>
 </div>
 
 <%= render 'step_card', locals: {
@@ -100,7 +101,7 @@
       <%= file_field_tag :device %>
       <%= submit_tag "Upload", class: "button" %>
       <% if params[:upload_status] %>
-          <span><%= params[:upload_status] %></span>
+        <span><%= params[:upload_status] %></span>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -44,3 +44,24 @@
     as associating your servers with your user account.
   </p>
 <% end %>
+<%= render 'step_card', locals: {
+  number: 4,
+  title: 'Upload your data manually',
+} do %>
+  <% content_for :buttons, :flush => true do %>
+    <%= link_to "Upload", action: :download_carbon %>
+  <% end %>
+  <p>
+    If your system has internet access, you can skip this step! Otherwise, the
+    Carbon Client will create a payload file at <code>carbon-log/payload-${UUID}.json</code>
+    which can be manually uploaded to the OpenFlight Carbon Leaderboard.
+  </p>
+<% end %>
+<%= render 'step_card', locals: {
+  number: 5,
+  title: 'See how your server does on the leaderboard!',
+} do %>
+  <% content_for :buttons, :flush => true do %>
+    <%= link_to "View leaderboard", leaderboard_path %>
+  <% end %>
+<% end %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,9 +1,19 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
 <div class="mb-4 text-center">
   <p>Is your server connected to the internet?</p>
-  <input type="radio" id="radio-yes" name="internet" value="yes" checked="checked">
+  <input type="radio"
+         id="radio-yes"
+         name="internet"
+         value="yes"
+         <%= 'checked="checked"' unless params[:offline_instructions] %>
+  >
   <label for="yes">Yes</label>
-  <input type="radio" id="radio-no" name="internet" value="no">
+  <input type="radio"
+         id="radio-no"
+         name="internet"
+         value="no"
+         <%= 'checked="checked"' if params[:offline_instructions] %>
+  >
   <label for="no">No</label>
 </div>
 

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -125,6 +125,7 @@
       optionally "claim" the device that is being sent. To do so, a user account
       will need to be created in the leaderboard and the <code>JWT_TOKEN</code>
       for the user will need to be set as the environment variable <code>AUTH_TOKEN</code>.
+      Your auth token can be found on your user profile page.
     </p>
   <% end %>
   <%= render 'advanced_instruction', locals: {

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -50,7 +50,7 @@
   </p>
   <p>
     For more options, such as associating your servers with your user account,
-    see the advanced usage information below.
+    see the advanced usage information <a href="#advanced-usage" class="below-link">below</a>.
   </p>
 <% end %>
 
@@ -84,8 +84,8 @@
   </p>
   <p>
     This will collect all the data you need to enter your server onto the leaderboard.
-    However, you can find information below about more advanced options, such
-    as associating your servers with your user account.
+    However, you can find information <a href="#advanced-usage" class="below-link">below</a>
+    about more advanced options, such as associating your servers with your user account.
   </p>
 <% end %>
 <%= render 'step_card', locals: {
@@ -114,7 +114,7 @@
   <% end %>
 <% end %>
 
-<div class="card wide-card advanced-card">
+<div id="advanced-usage" class="card wide-card advanced-card">
   <h3>Advanced usage options</h3>
   <%= render 'advanced_instruction', locals: {
     id: 'accountInstructions',

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
 <p class="text-center">Is your server connected to the internet?</p>
-<div class="btn-group radio-buttons flex-space-between" role="group" aria-label="internet-toggle">
+<div class="btn-group mb-5" role="group" aria-label="internet-toggle">
   <input type="radio"
          class="btn-check"
          name="btnradio"

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -8,14 +8,14 @@
          autocomplete="off"
          <%= 'checked' unless params[:offline_instructions] %>
   >
-  <label class="btn btn-outline-primary" for="radio-yes">Yes</label>
+  <label class="btn btn-outline-primary button glaring" for="radio-yes">Yes</label>
   <input type="radio"
          class="btn-check"
          name="btnradio" id="radio-no"
          autocomplete="off"
          <%= 'checked' if params[:offline_instructions] %>
   >
-  <label class="btn btn-outline-primary" for="radio-no">No</label>
+  <label class="btn btn-outline-primary button glaring" for="radio-no">No</label>
 </div>
 
 <%= render 'step_card', locals: {

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -115,54 +115,30 @@
 <hr class="wide-card">
 
 <div class="card wide-card advanced-card">
-      <h3>Advanced usage options</h3>
+  <h3>Advanced usage options</h3>
 
-      <div class="advanced-instruction-wrapper">
-        <button class="button"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#accountInstructions"
-                aria-expanded="false"
-                aria-controls="accountInstructions"
-        >
-          <span class="big-blue-plus">+</span>
-          <span class="big-text">Associating a device with your user account</span>
-        </button>
-        <div class="collapse" id="accountInstructions">
-          <br>
-          <p>
-            When collecting system information in the leaderboard it may be desired to
-            optionally "claim" the device that is being sent. To do so, a user account
-            will need to be created in the leaderboard and the <code>JWT_TOKEN</code>
-            for the user will need to be set as the environment variable <code>AUTH_TOKEN</code>.
-          </p>
-        </div>
-      </div>
-
-      <div class="step-instructions advanced-instruction-wrapper">
-        <button class="button" 
-                type="button" 
-                data-bs-toggle="collapse" 
-                data-bs-target="#locationInstructions" 
-                aria-expanded="false" 
-                aria-controls="locationInstructions"
-        >
-          <span class="big-blue-plus">+</span>
-          <span class="big-text">Specifying Location</span>
-        </button>
-        <div class="collapse" id="locationInstructions">
-          <br>
-          <p>
-            If the connection to the Internet goes via a VPN or proxy then the location
-            determined by the script may be incorrect. To override the automated location
-            identified, ensure that the environment variable <code>LOCATION</code> is set
-            to a valid ISO 3166-1 alpha-3 code.
-          </p>
-        </div>
-      </div>
-
-    </div>
-  </div>
+  <%= render 'advanced_instruction', locals: {
+    id: 'accountInstructions',
+    title: 'Associating a device with your user account',
+  } do %>
+    <p>
+      When collecting system information in the leaderboard it may be desired to
+      optionally "claim" the device that is being sent. To do so, a user account
+      will need to be created in the leaderboard and the <code>JWT_TOKEN</code>
+      for the user will need to be set as the environment variable <code>AUTH_TOKEN</code>.
+    </p>
+  <% end %>
+  <%= render 'advanced_instruction', locals: {
+    id: 'locationInstructions',
+    title: 'Specifying Location',
+  } do %>
+    <p>
+      If the connection to the Internet goes via a VPN or proxy then the location
+      determined by the script may be incorrect. To override the automated location
+      identified, ensure that the environment variable <code>LOCATION</code> is set
+      to a valid ISO 3166-1 alpha-3 code.
+    </p>
+  <% end %>
 </div>
 
 <script type="text/javascript" src="/assets/data_entry/index.js"></script>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,1 +1,18 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
+<div class="card mt-4">
+  <div class="step-wrapper">
+    <span class="step-number">1</span>
+    <div class="step">
+      <h3 class="step-title">Make an account (optional)</h3>
+      <div class="step-instructions">
+        <p>
+          Make an account to claim your servers on the leaderboard and get
+          access to tools for tracking your server emission stats more easily.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="step-actions flex-column-centred">
+    <%= link_to "Sign up", new_registration_path(:user) %>
+  </div>
+</div>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -2,13 +2,23 @@
 <%= render 'step_card', locals: {
   number: 1,
   title: 'Make an account (optional)',
-  instructions: 'Make an account to claim your servers on the leaderboard and get
-          access to tools for tracking your server emission stats more easily.',
-  }
-%>
+} do %>
+  <% content_for :buttons, :flush => true do %>
+    <%= link_to "Sign up", new_registration_path(:user) %>
+  <% end %>
+  <p>
+    Make an account to claim your servers on the leaderboard and get
+    access to tools for tracking your server emission stats more easily.
+  </p>
+<% end %>
 <%= render 'step_card', locals: {
   number: 2,
   title: 'Download the Carbon Client',
-  instructions: 'The Carbon Client is a BASH script which collects the required data for adding entries to the Carbon Leaderboard.',
-}
-%>
+} do %>
+  <% content_for :buttons, :flush => true do %>
+    <%= link_to "Download", action: :download_carbon %>
+  <% end %>
+  <p>
+    The Carbon Client is a BASH script which collects the required data for adding entries to the Carbon Leaderboard.
+  </p>
+<% end %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -114,8 +114,6 @@
   <% end %>
 <% end %>
 
-<hr class="wide-card">
-
 <div class="card wide-card advanced-card">
   <h3>Advanced usage options</h3>
   <%= render 'advanced_instruction', locals: {

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,0 +1,1 @@
+<h1 class="text-center mb-5">Enter your server data</h1>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -92,12 +92,12 @@
   show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
-    <%= form_with url: "/data-entry/upload", multipart: true do |form| %>
-      <%= file_field_tag :device %>
-      <%= submit_tag "Upload", class: "button" %>
-      <% if params[:upload_status] %>
-        <span><%= params[:upload_status] %></span>
-      <% end %>
+    <%= form_with url: "/data-entry/upload", multipart: true, class: 'file-input' do |form| %>
+      <%= file_field_tag :device, class: "form-control" %>
+      <%= submit_tag "Upload", class: "btn btn-outline-primary ml-3" %>
+    <% end %>
+    <% if params[:upload_status] %>
+      <span><%= params[:upload_status] %></span>
     <% end %>
   <% end %>
   <p>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,18 +1,14 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
-<div class="card mt-4">
-  <div class="step-wrapper">
-    <span class="step-number">1</span>
-    <div class="step">
-      <h3 class="step-title">Make an account (optional)</h3>
-      <div class="step-instructions">
-        <p>
-          Make an account to claim your servers on the leaderboard and get
-          access to tools for tracking your server emission stats more easily.
-        </p>
-      </div>
-    </div>
-  </div>
-  <div class="step-actions flex-column-centred">
-    <%= link_to "Sign up", new_registration_path(:user) %>
-  </div>
-</div>
+<%= render 'step_card', locals: {
+  number: 1,
+  title: 'Make an account (optional)',
+  instructions: 'Make an account to claim your servers on the leaderboard and get
+          access to tools for tracking your server emission stats more easily.',
+  }
+%>
+<%= render 'step_card', locals: {
+  number: 2,
+  title: 'Download the Carbon Client',
+  instructions: 'The Carbon Client is a BASH script which collects the required data for adding entries to the Carbon Leaderboard.',
+}
+%>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -35,7 +35,8 @@
   </p>
   <p class="code-wrapper">
     <code class="code-block">
-      curl -s -L https://github.com/openflighthpc/carbon-leaderboard/raw/main/carbon-client/carbon | COMMAND='send' ACCEPT_DEFAULTS='true' /bin/bash
+      curl -s -L https://github.com/openflighthpc/carbon-leaderboard/raw/main/carbon-client/carbon | COMMAND='send'
+      ACCEPT_DEFAULTS='true' /bin/bash
     </code>
   </p>
   <p>
@@ -110,5 +111,58 @@
     <%= link_to "View leaderboard", leaderboard_path %>
   <% end %>
 <% end %>
+
+<hr class="wide-card">
+
+<div class="card wide-card advanced-card">
+      <h3>Advanced usage options</h3>
+
+      <div class="advanced-instruction-wrapper">
+        <button class="button"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#accountInstructions"
+                aria-expanded="false"
+                aria-controls="accountInstructions"
+        >
+          <span class="big-blue-plus">+</span>
+          <span class="big-text">Associating a device with your user account</span>
+        </button>
+        <div class="collapse" id="accountInstructions">
+          <br>
+          <p>
+            When collecting system information in the leaderboard it may be desired to
+            optionally "claim" the device that is being sent. To do so, a user account
+            will need to be created in the leaderboard and the <code>JWT_TOKEN</code>
+            for the user will need to be set as the environment variable <code>AUTH_TOKEN</code>.
+          </p>
+        </div>
+      </div>
+
+      <div class="step-instructions advanced-instruction-wrapper">
+        <button class="button" 
+                type="button" 
+                data-bs-toggle="collapse" 
+                data-bs-target="#locationInstructions" 
+                aria-expanded="false" 
+                aria-controls="locationInstructions"
+        >
+          <span class="big-blue-plus">+</span>
+          <span class="big-text">Specifying Location</span>
+        </button>
+        <div class="collapse" id="locationInstructions">
+          <br>
+          <p>
+            If the connection to the Internet goes via a VPN or proxy then the location
+            determined by the script may be incorrect. To override the automated location
+            identified, ensure that the environment variable <code>LOCATION</code> is set
+            to a valid ISO 3166-1 alpha-3 code.
+          </p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
 
 <script type="text/javascript" src="/assets/data_entry/index.js"></script>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -116,7 +116,6 @@
 
 <div class="card wide-card advanced-card">
   <h3>Advanced usage options</h3>
-
   <%= render 'advanced_instruction', locals: {
     id: 'accountInstructions',
     title: 'Associating a device with your user account',
@@ -130,13 +129,63 @@
   <% end %>
   <%= render 'advanced_instruction', locals: {
     id: 'locationInstructions',
-    title: 'Specifying Location',
+    title: 'Specifying location',
   } do %>
     <p>
       If the connection to the Internet goes via a VPN or proxy then the location
       determined by the script may be incorrect. To override the automated location
       identified, ensure that the environment variable <code>LOCATION</code> is set
       to a valid ISO 3166-1 alpha-3 code.
+    </p>
+  <% end %>
+  <%= render 'advanced_instruction', locals: {
+    id: 'dependencies',
+    title: 'View dependencies',
+  } do %>
+    <p><code>BASH  </code></p>
+    <p><code>lshw  </code></p>
+    <p><code>lsblk </code></p>
+    <p><code>md5sum</code></p>
+  <% end %>
+  <%= render 'advanced_instruction', locals: {
+    id: 'silenceInstructions',
+    title: 'Silencing output',
+  } do %>
+    <p>
+      By default the script will print a one-line debug of the system specs when
+      <code>send</code> is run. This can be silenced by setting the environment
+      variable <code>QUIET</code> to <code>true</code>.
+    </p>
+  <% end %>
+  <%= render 'advanced_instruction', locals: {
+    id: 'payload',
+    title: 'Offline data collection (the payload file)',
+  } do %>
+    <p>
+      The payload file (<code>carbon-log/payload-${UUID}.json</code>) is created
+      by a device when it is unable to reach the leaderboard. This payload file can
+      have 1 or more entries for the device.
+    </p>
+    <p>
+      As the <code>send</code> command collects
+      the load average over the last 15 minutes for "live" carbon data, this file can
+      be used to build up many entries over time for a single device in order to get
+      historical estimates of the actual impact of the device at whatever load it has
+      been at.
+    </p>
+  <% end %>
+  <%= render 'advanced_instruction', locals: {
+    id: 'acceptDefaults',
+    title: 'Accepting defaults',
+  } do %>
+    <p>
+      By default the script will prompt confirmation of the various system specs with
+      the user. To prevent this from happening in the future set the environment variable
+      <code>ACCEPT_DEFAULTS</code> to <code>true</code>.
+    </p>
+    <p>
+      Note: Overrides to system specs only happen on a per-run basis so would need to be
+      overridden each time the command is run.
     </p>
   <% end %>
 </div>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -1,7 +1,16 @@
 <h1 class="text-center mb-5">Enter your server data</h1>
+<div class="mb-4">
+  <p>Is your server connected to the internet?</p>
+  <input type="radio" id="radio-yes" name="age" value="yes">
+  <label for="yes">Yes</label>
+  <input type="radio" id="radio-no" name="age" value="no">
+  <label for="no">No</label>
+</div>
+
 <%= render 'step_card', locals: {
   number: 1,
   title: 'Make an account (optional)',
+  show_card: { online: true, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
     <%= link_to "Sign up", new_registration_path(:user) %>
@@ -14,6 +23,7 @@
 <%= render 'step_card', locals: {
   number: 2,
   title: 'Download the Carbon Client',
+  show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
     <%= link_to "Download", action: :download_carbon %>
@@ -27,6 +37,7 @@
   number: 3,
   title: 'Run the Carbon Client on your server',
   hide_actions: true,
+  show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
     <div></div>
@@ -47,6 +58,7 @@
 <%= render 'step_card', locals: {
   number: 4,
   title: 'Upload your data manually',
+  show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
     <%= form_with url: "/data-entry/upload", multipart: true do |form| %>
@@ -70,8 +82,11 @@
 <%= render 'step_card', locals: {
   number: 5,
   title: 'See how your server does on the leaderboard!',
+  show_card: { online: true, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
     <%= link_to "View leaderboard", leaderboard_path %>
   <% end %>
 <% end %>
+
+<script type="text/javascript" src="/assets/data_entry/index.js"></script>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -100,11 +100,7 @@
       <%= file_field_tag :device %>
       <%= submit_tag "Upload", class: "button" %>
       <% if params[:upload_status] %>
-        <% if params[:upload_status].empty? %>
-          <span>Upload successful</span>
-        <% else %>
-          <span>Upload failed: <%= params[:upload_status] %></span>
-        <% end %>
+          <span><%= params[:upload_status] %></span>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -49,7 +49,10 @@
   title: 'Upload your data manually',
 } do %>
   <% content_for :buttons, :flush => true do %>
-    <%= link_to "Upload", action: :download_carbon %>
+    <%= form_with url: "/data-entry/upload", multipart: true do |form| %>
+      <%= file_field_tag :device %>
+      <%= submit_tag "Upload", class: "button" %>
+    <% end %>
   <% end %>
   <p>
     If your system has internet access, you can skip this step! Otherwise, the

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -68,6 +68,7 @@
 <% end %>
 <%= render 'step_card', locals: {
   title: 'Run the Carbon Client on your server',
+  id: 'anchor-card',
   hide_actions: true,
   show_card: { online: false, offline: true },
 } do %>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -52,6 +52,13 @@
     <%= form_with url: "/data-entry/upload", multipart: true do |form| %>
       <%= file_field_tag :device %>
       <%= submit_tag "Upload", class: "button" %>
+      <% if params[:upload_status] %>
+        <% if params[:upload_status].empty? %>
+          <span>Upload successful</span>
+        <% else %>
+          <span>Upload failed: <%= params[:upload_status] %></span>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
   <p>

--- a/app/views/data_entry/index.html.erb
+++ b/app/views/data_entry/index.html.erb
@@ -23,7 +23,7 @@
   show_card: { online: true, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
-    <%= link_to "Sign up", new_registration_path(:user) %>
+    <%= link_to "Sign up", new_registration_path(:user), class: 'button glaring' %>
   <% end %>
   <p>
     Make an account to claim your servers on the leaderboard and get
@@ -59,7 +59,7 @@
   show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
-    <%= link_to "Download", action: :download_carbon %>
+    <%= link_to "Download", { action: :download_carbon }, class: 'button glaring' %>
   <% end %>
   <p>
     The Carbon Client is a BASH script which collects the required data for
@@ -93,9 +93,9 @@
   show_card: { online: false, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
-    <%= form_with url: "/data-entry/upload", multipart: true, class: 'file-input' do |form| %>
+    <%= form_with url: "/data-entry/upload", multipart: true, class: 'file-input flex-space-between' do |form| %>
       <%= file_field_tag :device, class: "form-control" %>
-      <%= submit_tag "Upload", class: "btn btn-outline-primary ml-3" %>
+      <%= submit_tag "Upload", class: "button glaring" %>
     <% end %>
     <% if params[:upload_status] %>
       <span><%= params[:upload_status] %></span>
@@ -110,7 +110,7 @@
   show_card: { online: true, offline: true },
 } do %>
   <% content_for :buttons, :flush => true do %>
-    <%= link_to "View leaderboard", leaderboard_path %>
+    <%= link_to "View leaderboard", leaderboard_path, class: 'button glaring' %>
   <% end %>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="actions submit-button flex-column-centred">
-      <%= f.submit "Send me reset password instructions" %>
+      <%= f.submit "Send me reset password instructions", class: 'button glaring' %>
     </div>
   <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,7 +31,7 @@
     </div>
 
     <div class="actions submit-button flex-column-centred">
-      <%= f.submit "Sign up" %>
+      <%= f.submit "Sign up", class: 'button glaring' %>
     </div>
   <% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,7 @@
   Finding the most carbon efficient HPC solutions by ranking the emissions of real servers.
 </p>
 
-<%= button_to "Enter your server data", data_entry_path, class: 'button big-text my-4', method: :get %>
+<%= button_to "Enter your server data", data_entry_path, class: 'button glaring big-text my-5', method: :get %>
 
 <div class="home-top-section my-4">
   <%= render 'counter', locals: { number: @num_devices, text: 'servers entered' } %>
@@ -32,7 +32,7 @@
           <% end %>
         </div>
       </div>
-      <%= button_to "View full leaderboard", leaderboard_path, class: 'button mt-3', method: :get %>
+      <%= button_to "View full leaderboard", leaderboard_path, class: 'button glaring mt-3', method: :get %>
     <% end %>
   </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,7 @@
   Finding the most carbon efficient HPC solutions by ranking the emissions of real servers.
 </p>
 
-<%= button_to "Enter your server data", root_path, class: 'button big-text my-4', method: :get %>
+<%= button_to "Enter your server data", data_entry_path, class: 'button big-text my-4', method: :get %>
 
 <div class="home-top-section my-4">
   <%= render 'counter', locals: { number: @num_devices, text: 'servers entered' } %>

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -12,8 +12,8 @@
     </a>
 
   <div class="centre section">
-      <div id="leaderboard-link-wrapper" class="nav-link-wrapper nav-link-dropdown-wrapper d-flex align-items-center">
-        <%= link_to "Leaderboards", leaderboard_path, class: "nav-link px-3" %>
+    <div id="leaderboard-link-wrapper" class="nav-link-wrapper nav-link-dropdown-wrapper d-flex align-items-center">
+        <%= link_to "Leaderboards", leaderboard_path, class: "nav-link" %>
         <div class="dropdown-wrapper d-flex justify-content-center">
           <ul class="dropdown-list blurred-frame white-outline">
             <%= link_to "Individual leaderboard", leaderboard_path, class: "nav-dropdown-link px-2 glaring" %>
@@ -21,9 +21,8 @@
           </ul>
         </div>
       </div>
-      <div id="leaderboard-link-wrapper" class="nav-link-wrapper d-flex align-items-center">
-        <%= link_to "Servers", show_devices_path, class: "nav-link px-3" %>
-      </div>
+    <%= link_to "Enter server data", data_entry_path, class: "nav-link" %>
+    <%= link_to "Servers", show_devices_path, class: "nav-link" %>
   </div>
 
   <div class="top-right section">

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -28,7 +28,10 @@
   <div class="top-right section">
     <% if user_signed_in? %>
       <div id="leaderboard-link-wrapper" class="nav-link-wrapper nav-link-dropdown-wrapper d-flex align-items-center">
-        <%= link_to "#{['Hi', 'Hello', 'Welcome'].sample}, #{current_user.username}", "#", class: "nav-link px-3" %>
+        <%= link_to "#{['Hi', 'Hello', 'Welcome'].sample}, #{current_user.username}",
+                    "/user/#{current_user.username}",
+                    class: "nav-link px-3"
+        %>
         <div class="dropdown-wrapper d-flex justify-content-center">
           <ul class="dropdown-list blurred-frame white-outline">
             <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "nav-dropdown-link last-item px-2 glaring" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -21,7 +21,7 @@
       <% end %>
 
       <div class="actions submit-button">
-        <%= f.submit "Log in" %>
+        <%= f.submit "Log in", class: 'button glaring' %>
       </div>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
   post "/delete-tag/:device",      to: "device#delete_tag"
 
   get "/user/:username",           to: "user#profile"
+
+  get "/data-entry",               to: "data_entry#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
   get "/user/:username",           to: "user#profile"
 
   get "/data-entry",               to: "data_entry#index"
+  get 'download_carbon',           to: "data_entry#download_carbon"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,6 @@ Rails.application.routes.draw do
   get "/user/:username",           to: "user#profile"
 
   get "/data-entry",               to: "data_entry#index"
-  get 'download_carbon',           to: "data_entry#download_carbon"
+  get "/download-carbon",          to: "data_entry#download_carbon"
   post "/data-entry/upload",       to: "data_entry#upload"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,5 @@ Rails.application.routes.draw do
 
   get "/data-entry",               to: "data_entry#index"
   get 'download_carbon',           to: "data_entry#download_carbon"
+  post "/data-entry/upload",       to: "data_entry#upload"
 end


### PR DESCRIPTION
Adds page with instructions for entering server data, including a button for downloading the carbon client script and a functioning UI for uploading payload files.

Also adds Marco's generic button styling from the login redesign PR

Known limitations: 
- 'Browse...' files button doesn't have consistent styling with other buttons
- Code blocks don't have buttons that can automatically copy the code

Both of those would have been relatively time consuming to add so have been left for now. Could fix them now or go back to it if we've got time

![image](https://github.com/openflighthpc/carbon-leaderboard/assets/102584263/be8802dd-abf3-43be-a79d-8f73253d29c9)
