### PR TITLE
Introduce device grouping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,11 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-/config/credentials.ymc.enc
+/config/credentials.yml.enc
+/config/credentials/production.yml.enc
 
 # Ignore rubymine files
 .idea/*
 
+
+/config/credentials/production.key

--- a/app/controllers/device_controller.rb
+++ b/app/controllers/device_controller.rb
@@ -45,6 +45,43 @@ class DeviceController < ApplicationController
     render json: response
   end
 
+  def grouped_data
+    devices = Device.select('devices.*, max / (cpus * cores_per_cpu) AS max_per_core')
+    .group(:group)
+    .order(:max_per_core)
+    response = {}.tap do |res|
+      max_device = devices.last
+      res[:max_main] = max_device&.max_per_core&.round(3);
+      res[:header] = {}.tap do |h|
+        h[:user] = 'Group'
+        h[:platform] = 'Platform'
+        h[:location] = 'Location'
+        h[:core_number] = 'No. cores'
+        h[:ram] = 'RAM (GB)'
+        h[:main] = 'Carbon emissions per core at full load (kgCO2eq/h)'
+      end
+      rank = 1
+      res[:devices] = devices
+      .group_by(&:max_per_core)
+      .values.flat_map do |dev_group|
+        current_rank = rank
+        rank += dev_group.size
+        dev_group.map do |dev|
+          {}.tap do |new_dev|
+            new_dev[:rank] = current_rank
+            new_dev[:user] = "Group \##{dev.group}"
+            new_dev[:platform] = dev.platform
+            new_dev[:location] = dev.location
+            new_dev[:core_number] = dev.cpus * dev.cores_per_cpu
+            new_dev[:ram] = dev.ram_units * dev.ram_capacity_per_unit
+            new_dev[:main] = dev.max_per_core.round(3)
+          end
+        end
+      end
+    end
+    render json: response
+  end
+
   def add_tag
     device = Device.find_by(display_name: params[:device])
     if device.user_id == @current_user.id

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -15,10 +15,7 @@ class HomeController < ApplicationController
       }
     end
     @num_devices = Device.all.length
-    config_attributes = Device.attribute_names.filter do |attr|
-      !%w(uuid user_id created_at updated_at tags).include?(attr)
-    end
-    @num_configs = Device.all.pluck(config_attributes).uniq.length
+    @num_configs = Device.select(:group).distinct.length
   end
 end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -36,6 +36,7 @@ class ReportController < ApplicationController
         device.min = Boavizta.carbon_for_load(device, 0)
         device.half = Boavizta.carbon_for_load(device, 50)
         device.max = Boavizta.carbon_for_load(device, 100)
+        device.group = device.determine_group
         device.save
       else
         render json: "Error(s) with payload data: #{device.errors.full_messages.join(', ')}"

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -3,6 +3,10 @@ class ReportController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :authorize_anonymous, :only=>[:add_record]
 
+  def index
+    @grouped = params[:grouped]
+  end
+
   def show
     @user = User.find_by(username: params[:name])
     if @user

--- a/app/javascript/report/index.js
+++ b/app/javascript/report/index.js
@@ -19,13 +19,22 @@ $(document).ready(async () => {
   //     })
   //   }
   // ));
-
-  const leaderboardResponse = await fetch(
-    '/leaderboard/raw-data',
-    {
-      method: 'GET'
-    }
-  );
+  var leaderboardResponse
+  if (grouped) {
+    leaderboardResponse = await fetch(
+      '/leaderboard/grouped-data',
+      {
+        method: 'GET'
+      }
+    );
+  } else {
+    leaderboardResponse = await fetch(
+      '/leaderboard/raw-data',
+      {
+        method: 'GET'
+      }
+    );
+  };
   const {max_main, header, devices} = await leaderboardResponse.json();
   $('#leaderboard-bar-value-wrapper').text(header.main);
   delete header.main;

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -25,12 +25,12 @@ class Device < ApplicationRecord
   end
 
   def determine_group
-    group_devices = Device.all.group(:group).where.not(uuid: self.uuid)
+    group_devices = Device.group(:group).where.not(uuid: self.uuid)
     group_devices.each do |device|
       if self.config_attributes == device.config_attributes
         return device.group
       end
     end
-    group_devices.length
+    Device.pluck(:group).max.to_i + 1
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -17,4 +17,20 @@ class Device < ApplicationRecord
   def two_digit_location
     ISO3166::Country.find_country_by_alpha3(self.location).alpha2
   end
+
+  def config_attributes
+    self.attributes.filter do |attr|
+      !%w(uuid user_id created_at updated_at tags display_name group).include?(attr)
+    end
+  end
+
+  def determine_group
+    group_devices = Device.all.group(:group).where.not(uuid: self.uuid)
+    group_devices.each do |device|
+      if self.config_attributes == device.config_attributes
+        return device.group
+      end
+    end
+    group_devices.length
+  end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -31,6 +31,6 @@ class Device < ApplicationRecord
         return device.group
       end
     end
-    Device.pluck(:group).max.to_i + 1
+    Device.pluck(:group).compact.max.to_i + 1
   end
 end

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -16,8 +16,8 @@
         <%= link_to "Leaderboards", leaderboard_path, class: "nav-link px-3" %>
         <div class="dropdown-wrapper d-flex justify-content-center">
           <ul class="dropdown-list blurred-frame white-outline">
-            <%= link_to "Device leaderboard", leaderboard_path, class: "nav-dropdown-link px-2 glaring" %>
-            <%= link_to "Server leaderboard", leaderboard_path, class: "nav-dropdown-link last-item px-2 glaring" %>
+            <%= link_to "Individual leaderboard", leaderboard_path, class: "nav-dropdown-link px-2 glaring" %>
+            <%= link_to "Grouped leaderboard", leaderboard_grouped_path, class: "nav-dropdown-link last-item px-2 glaring" %>
           </ul>
         </div>
       </div>

--- a/app/views/report/index.html.erb
+++ b/app/views/report/index.html.erb
@@ -1,5 +1,6 @@
 <h1>OpenFlight Carbon Leaderboard</h1>
 <h3 class="light-text">Servers with the lowest CO<sub>2</sub> emissions</h3>
+<h4 class="light-text"><%= "Grouped by identical specs" if @grouped %><h4>
 
 <div class="leaderboard-wrapper full-leaderboard">
   <div class="leaderboard-header-wrapper blurred-frame rounded-shape white-outline">
@@ -13,5 +14,8 @@
   <div class="leaderboard-content-wrapper"></div>
 </div>
 
+<script type="text/javascript">
+  var grouped = <%= @grouped %>
+</script>
 <script type="text/javascript" src="/assets/report/index.js"></script>
 <script type="text/javascript" src="/assets/report/glare.js"></script>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,13 +21,13 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  #config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   get "/show-devices",             to: "device#index"
   get "/leaderboard/raw-data",     to: "device#raw_data"
+  get "/leaderboard/grouped-data", to: "device#grouped_data"
   get "/device/:device",           to: "device#show"
   post "/add-tag/:device",         to: "device#add_tag"
   post "/delete-tag/:device",      to: "device#delete_tag"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { sessions: "users/sessions", registrations: "users/registrations" }
   root "home#index"
 
-  get "/leaderboard",              to: "report#index"
+  get "/leaderboard",              to: "report#index", defaults: { grouped: false }
+  get "/leaderboard/grouped",      to: "report#index", defaults: { grouped: true }
   post "/add-record",              to: "report#add_record"
 
   get "/show-devices",             to: "device#index"

--- a/db/migrate/20240430110330_add_group_to_devices.rb
+++ b/db/migrate/20240430110330_add_group_to_devices.rb
@@ -1,0 +1,5 @@
+class AddGroupToDevices < ActiveRecord::Migration[7.1]
+  def change
+    add_column :devices, :group, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_23_175345) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_30_110330) do
   create_table "devices", id: false, force: :cascade do |t|
     t.string "uuid"
     t.integer "user_id"
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_23_175345) do
     t.string "cloud_provider"
     t.string "instance_type"
     t.string "display_name"
+    t.integer "group"
     t.index ["user_id"], name: "index_devices_on_user_id"
   end
 


### PR DESCRIPTION
This PR introduces the integer `group` column to the Device table.
* Devices will have a matching `group` if and only if they also match in all other hardware-specific attributes (aside from `uuid`).
* A new data endpoint, `grouped_data`, has been added. The output format matches that of `raw_data`, but there's only one entry for each group.
* Some minor frontend changes were made to implement the new leaderboard and switch to it using the dropdown in the navbar. I'm not tied to any of the design decisions here, and it might be a stretch to even call them "decisions" given that my front-end knowledge doesn't leave me with many alternatives. They're all part of the same commit so should be easy to revert if desired.

This PR also fixes some issues which prevented page assets from working properly in production mode.