### PR TITLE
Fix cramped leaderboard layout

### DIFF
--- a/app/assets/stylesheets/leaderboard.css
+++ b/app/assets/stylesheets/leaderboard.css
@@ -46,7 +46,7 @@
 }
 
 .user-column{
-  width: calc(150 * var(--fpx));
+  width: calc(250 * var(--fpx));
 }
 
 .owner-column{

--- a/app/views/report/index.html.erb
+++ b/app/views/report/index.html.erb
@@ -1,6 +1,6 @@
 <h1>OpenFlight Carbon Leaderboard</h1>
 <h3 class="light-text">Servers with the lowest CO<sub>2</sub> emissions</h3>
-<h4 class="light-text"><%= "Grouped by identical specs" if @grouped %><h4>
+<h4 class="light-text"><%= "Grouped by identical specs" if @grouped %></h4>
 
 <div class="leaderboard-wrapper full-leaderboard">
   <div class="leaderboard-header-wrapper blurred-frame rounded-shape white-outline">


### PR DESCRIPTION
Small PR that:
 
- increases the width of the leaderboard 
- makes the server name column big enough to accommodate the longest device names