### PR TITLE
Group page and collateral improvements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -296,7 +296,7 @@ ul {
 }
 
 .server-list-wrapper {
-    max-height: calc(450 * var(--fpx));
+    max-height: calc(400 * var(--fpx));
     overflow-y: scroll;
 }
 .server-in-list {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -294,7 +294,14 @@ ul {
     left: 2rem;
     list-style-type: circle;
 }
-        
-strong {
-    font-weight: 600;
+
+.server-in-list {
+    display: flex;
+    justify-content: center;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    text-wrap: nowrap;
+}
+.server-in-list:hover {
+    color: var(--color-main);
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -295,6 +295,10 @@ ul {
     list-style-type: circle;
 }
 
+.server-list-wrapper {
+    max-height: calc(450 * var(--fpx));
+    overflow-y: scroll;
+}
 .server-in-list {
     display: flex;
     justify-content: center;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -141,11 +141,14 @@ a {
 .inline-link {
     display: inline;
     margin-right: -4px;
+}
+.text-link {
     color: var(--color-main);
 }
-.inline-link:hover {
+.text-link:hover {
     filter: brightness(0.8);
 }
+
 
 code {
     color: var(--color-text);
@@ -295,8 +298,13 @@ ul {
     list-style-type: circle;
 }
 
+strong {
+    font-weight: 600;
+}
+
 .server-list-card {
     min-width: 25rem;
+    max-width: 32rem;
 }
 .server-list-wrapper {
     max-height: calc(400 * var(--fpx));

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -301,22 +301,3 @@ ul {
 strong {
     font-weight: 600;
 }
-
-.server-list-card, .rankings-card {
-    min-width: 25rem;
-    max-width: 32rem;
-}
-.server-list-wrapper {
-    max-height: calc(400 * var(--fpx));
-    overflow-y: scroll;
-}
-.server-in-list {
-    display: flex;
-    justify-content: center;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    text-wrap: nowrap;
-}
-.server-in-list:hover {
-    color: var(--color-main);
-}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -250,19 +250,21 @@ code {
 }
 
 .button:hover {
-    border: 0 solid #2794d800;
-    color: #fff;
-    background-color: #404040;
-    line-height: calc(2rem + 4px);
     transform: scale(1.1);
-    filter: drop-shadow(var(--fpx) var(--fpx) calc(3 * var(--fpx)) #404040);
-    user-select: none;
+    line-height: calc(2rem + 4px);
     transition:
             border 72ms ease-out,
             color 72ms ease-out,
             transform 72ms ease-out,
             filter 72ms ease-out,
             background-color 72ms ease-out;
+}
+.button:hover, .server-in-list:hover {
+    border: 0 solid #2794d800;
+    color: #fff;
+    background-color: #404040;
+    filter: drop-shadow(var(--fpx) var(--fpx) calc(3 * var(--fpx)) #404040);
+    user-select: none;
 }
 
 .button:active {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -302,7 +302,7 @@ strong {
     font-weight: 600;
 }
 
-.server-list-card {
+.server-list-card, .rankings-card {
     min-width: 25rem;
     max-width: 32rem;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -295,6 +295,9 @@ ul {
     list-style-type: circle;
 }
 
+.server-list-card {
+    min-width: 25rem;
+}
 .server-list-wrapper {
     max-height: calc(400 * var(--fpx));
     overflow-y: scroll;

--- a/app/assets/stylesheets/data_entry.css
+++ b/app/assets/stylesheets/data_entry.css
@@ -45,11 +45,15 @@
     padding: 0.7rem 1.4rem;
     margin-top: 1rem;
     cursor: pointer;
-    transition: background-color 360ms ease-out;
 }
-.advanced-instruction-wrapper:hover {
+.advanced-instruction-wrapper, .server-in-list {
+    transition: background-color 360ms ease-out,
+                color 360ms ease-out;
+}
+.advanced-instruction-wrapper:hover, .server-in-list:hover {
     background-color: rgba(255, 255, 255, 0.3);
-    transition: background-color 72ms ease-out;
+    transition: background-color 72ms ease-out,
+                color 72ms ease-out;
 }
 
 .big-blue-plus {

--- a/app/assets/stylesheets/devices.css
+++ b/app/assets/stylesheets/devices.css
@@ -43,3 +43,22 @@
 .device-specs-grid .storage {
     grid-area: storage;
 }
+
+.server-list-card, .rankings-card {
+    min-width: 25rem;
+    max-width: 32rem;
+}
+.server-list-wrapper {
+    max-height: calc(400 * var(--fpx));
+    overflow-y: scroll;
+}
+.server-in-list {
+    display: flex;
+    justify-content: center;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    text-wrap: nowrap;
+}
+.server-in-list:hover {
+    color: var(--color-main);
+}

--- a/app/assets/stylesheets/devices.css
+++ b/app/assets/stylesheets/devices.css
@@ -52,6 +52,17 @@
     flex-grow: 1;
 }
 
+.emissions-wrapper {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    column-gap: 1rem;
+}
+.emission-number {
+    font-weight: 600;
+    color: var(--color-main);
+    font-size: 2rem;
+}
+
 .server-list-card, .rankings-card {
     min-width: 25rem;
     max-width: 32rem;

--- a/app/assets/stylesheets/devices.css
+++ b/app/assets/stylesheets/devices.css
@@ -52,17 +52,6 @@
     flex-grow: 1;
 }
 
-.emissions-wrapper {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    column-gap: 1rem;
-}
-.emission-number {
-    font-weight: 600;
-    color: var(--color-main);
-    font-size: 2rem;
-}
-
 .server-list-card, .rankings-card {
     min-width: 25rem;
     max-width: 32rem;

--- a/app/assets/stylesheets/devices.css
+++ b/app/assets/stylesheets/devices.css
@@ -59,14 +59,24 @@
 .server-list-wrapper {
     max-height: calc(400 * var(--fpx));
     overflow-y: scroll;
+    overflow-x: hidden;
+    width: min(30rem, 80%);
 }
 .server-in-list {
     display: flex;
     justify-content: center;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
+    margin: 0 0.5rem 0.5rem;
     text-wrap: nowrap;
+    border-radius: 2rem;
+    position: relative;
 }
 .server-in-list:hover {
     color: var(--color-main);
+    transition:
+            border 72ms ease-out,
+            color 72ms ease-out,
+            filter 72ms ease-out,
+            background-color 72ms ease-out;
 }

--- a/app/assets/stylesheets/devices.css
+++ b/app/assets/stylesheets/devices.css
@@ -44,6 +44,14 @@
     grid-area: storage;
 }
 
+.specs-rank-section {
+    display: flex;
+    gap: 1.5rem;
+}
+.specs-rank-section > div {
+    flex-grow: 1;
+}
+
 .server-list-card, .rankings-card {
     min-width: 25rem;
     max-width: 32rem;

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -16,7 +16,10 @@
 }
 .big-icon {
     font-size: 6rem;
-    color: var(--color-main);
+    background-color: var(--color-main);
+    background: linear-gradient(to right, #15c78e, #00D12E);
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
 }
 
 .driving-wrapper {

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -6,6 +6,7 @@
 
 .emission-wrapper {
     padding: 2rem;
+    font-size: 1.4rem;
 }
 
 .emission-number {
@@ -21,7 +22,6 @@
 .driving-wrapper {
     display: flex;
     gap: 0.7rem;
-    font-size: 1.4rem;
 }
 .driving {
     text-align: end;
@@ -32,9 +32,6 @@
     line-height: 2.2rem;
 }
 
-.flight-wrapper {
-    font-size: 1.4rem;
-}
 .flight-wrapper .people span {
     line-height: 1rem;
 }
@@ -44,4 +41,23 @@
 }
 .plane-icon {
     transform: rotate(-45deg);
+}
+
+.burger-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+}
+.big-mac-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    line-height: 1.6rem;
+}
+.burger-wrapper .emission-number {
+    line-height: 2.4rem;
+}
+.burger-wrapper .mcplant {
+    text-align: center;
 }

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -1,0 +1,29 @@
+.emissions-wrapper {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    column-gap: 1.5rem;
+}
+
+.emission-wrapper {
+    padding: 2rem;
+}
+
+.emission-number {
+    font-weight: 600;
+    color: var(--color-main);
+    font-size: 2.2rem;
+}
+
+.driving-wrapper {
+    display: flex;
+    gap: 0.7rem;
+    font-size: 1.4rem;
+}
+.driving {
+    text-align: end;
+    flex-grow: 1;
+    line-height: 1.6rem;
+}
+.miles {
+    line-height: 2.2rem;
+}

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -13,6 +13,7 @@
     font-weight: 600;
     color: var(--color-main);
     font-size: 2.2rem;
+    line-height: 2.4rem;
 }
 .big-icon {
     font-size: 6rem;
@@ -29,10 +30,17 @@
 .driving {
     text-align: end;
     flex-grow: 1;
-    line-height: 1.6rem;
+    line-height: 2rem;
 }
 .miles {
     line-height: 2.2rem;
+}
+.driving-icon {
+    font-size: 7rem;
+}
+.driving-icon-wrapper {
+    position: absolute;
+    bottom: 1.5rem;
 }
 
 .flight-wrapper .people span {
@@ -46,10 +54,15 @@
     transform: rotate(-45deg);
 }
 
-.burger-wrapper {
+.netflix-icon {
+    font-size: 5.5rem;
+}
+
+.burger-wrapper, .netflix-wrapper {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    align-items: center;
     height: 100%;
 }
 .big-mac-wrapper {

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -27,3 +27,9 @@
 .miles {
     line-height: 2.2rem;
 }
+.fa-solid {
+    color: var(--color-main);
+}
+.car-icon {
+    font-size: 6rem;
+}

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -13,6 +13,10 @@
     color: var(--color-main);
     font-size: 2.2rem;
 }
+.big-icon {
+    font-size: 6rem;
+    color: var(--color-main);
+}
 
 .driving-wrapper {
     display: flex;
@@ -27,9 +31,17 @@
 .miles {
     line-height: 2.2rem;
 }
-.fa-solid {
-    color: var(--color-main);
+
+.flight-wrapper {
+    font-size: 1.4rem;
 }
-.car-icon {
-    font-size: 6rem;
+.flight-wrapper .people span {
+    line-height: 1rem;
+}
+.people-plane {
+    display: flex;
+    gap: 1rem;
+}
+.plane-icon {
+    transform: rotate(-45deg);
 }

--- a/app/assets/stylesheets/emission_conversions.css
+++ b/app/assets/stylesheets/emission_conversions.css
@@ -43,15 +43,25 @@
     bottom: 1.5rem;
 }
 
+.flight-wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
 .flight-wrapper .people span {
     line-height: 1rem;
 }
 .people-plane {
     display: flex;
+    justify-content: space-between;
+    flex-grow: 1;
     gap: 1rem;
 }
 .plane-icon {
-    transform: rotate(-45deg);
+    transform: rotate(-135deg);
+    font-size: 7rem;
+    position: absolute;
+    right: 2.5rem;
 }
 
 .netflix-icon {

--- a/app/assets/stylesheets/leaderboard.css
+++ b/app/assets/stylesheets/leaderboard.css
@@ -186,6 +186,9 @@
 .leaderboard-item-wrapper.rank-3 .rank-column{
   background-color: #CD7F32;
 }
+.leaderboard-item-wrapper.solid-rank .rank-column{
+  background-color: var(--color-main);
+}
 .leaderboard-item-wrapper.rank-other .rank-column {
   height: calc(36 * var(--fpx));
   line-height: calc(36 * var(--fpx));

--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -11,8 +11,8 @@ class GroupController < ApplicationController
   def raw_data
     kg = params[:unit] == 'kg_per_year'
     devices = Device.select('devices.*, max / (cpus * cores_per_cpu) AS max_per_core')
-    .group(:group)
-    .order(:max_per_core)
+                    .group(:group)
+                    .order(:max_per_core)
     response = {}.tap do |res|
       max_device = devices.last
       res[:max_main] = max_device&.max_per_core * (kg ? 8.76 : 1)
@@ -26,8 +26,8 @@ class GroupController < ApplicationController
       end
       rank = 1
       res[:groups] = devices
-      .group_by(&:max_per_core)
-      .values.flat_map do |dev_group|
+                       .group_by(&:max_per_core)
+                       .values.flat_map do |dev_group|
         current_rank = rank
         rank += dev_group.size
         dev_group.map do |dev|

--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -18,9 +18,7 @@ class GroupController < ApplicationController
 
   def raw_data
     kg = params[:unit] == 'kg_per_year'
-    devices = Device.select('devices.*, max / (cpus * cores_per_cpu) AS max_per_core')
-                    .group(:group)
-                    .order(:max_per_core)
+    devices = Device.groups_ranked
     response = {}.tap do |res|
       max_device = devices.last
       res[:max_main] = max_device&.max_per_core * (kg ? 8.76 : 1)

--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -6,6 +6,13 @@ class GroupController < ApplicationController
 
   def show
     @group = Device.where(group: params[:group_id])
+    @year_emissions = (@group.first.max * 8.76).round(2)
+    @emission_conversions = {}.tap do |ec|
+      ec[:driving] = (@year_emissions * EmissionConversion::DRIVE).floor
+      ec[:big_mac] = (@year_emissions * EmissionConversion::BIG_MAC).floor
+      ec[:mcplant] = (@year_emissions * EmissionConversion::MCPLANT).floor
+      ec[:flight] = (@year_emissions * EmissionConversion::FLIGHT).floor
+    end
     @user_devices = @group.pluck(:user_id)
                           .uniq
                           .compact

--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -12,7 +12,7 @@ class GroupController < ApplicationController
       ec[:big_mac] = (@year_emissions * EmissionConversion::BIG_MAC).floor
       ec[:mcplant] = (@year_emissions * EmissionConversion::MCPLANT).floor
       ec[:flight] = (@year_emissions * EmissionConversion::FLIGHT).floor
-      ec[:netflix] = (@year_emissions / 2 * EmissionConversion::NETFLIX).floor
+      ec[:netflix] = (@year_emissions * EmissionConversion::NETFLIX).floor
     end
     @user_devices = @group.pluck(:user_id)
                           .uniq

--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -12,6 +12,7 @@ class GroupController < ApplicationController
       ec[:big_mac] = (@year_emissions * EmissionConversion::BIG_MAC).floor
       ec[:mcplant] = (@year_emissions * EmissionConversion::MCPLANT).floor
       ec[:flight] = (@year_emissions * EmissionConversion::FLIGHT).floor
+      ec[:netflix] = (@year_emissions / 2 * EmissionConversion::NETFLIX).floor
     end
     @user_devices = @group.pluck(:user_id)
                           .uniq

--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -6,6 +6,14 @@ class GroupController < ApplicationController
 
   def show
     @group = Device.where(group: params[:group_id])
+    @user_devices = @group.pluck(:user_id)
+                          .uniq
+                          .compact
+                          .map do |id|
+      [User.find(id).username, @group.where(user_id: id).pluck(:display_name)]
+    end
+    @anon_devices = @group.where(user_id: nil)
+                          .pluck(:display_name)
   end
 
   def raw_data

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -3,5 +3,6 @@ class UserController < ApplicationController
   def profile
     @user = User.find_by(username: params[:username])
     @user_owns_profile = user_signed_in? && @user&.id == current_user.id
+    @devices = Device.where(user_id: @user.id)
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -4,6 +4,8 @@ class UserController < ApplicationController
     @user = User.find_by(username: params[:username])
     @user_owns_profile = user_signed_in? && @user&.id == current_user.id
     @devices = Device.where(user_id: @user.id)
-    @groups = @devices.pluck(:group).uniq
+    @groups = @devices.pluck(:group)
+                      .uniq
+                      .sort_by { |group_id| @devices.find_by(group: group_id).rank }
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -4,5 +4,6 @@ class UserController < ApplicationController
     @user = User.find_by(username: params[:username])
     @user_owns_profile = user_signed_in? && @user&.id == current_user.id
     @devices = Device.where(user_id: @user.id)
+    @groups = @devices.pluck(:group).uniq
   end
 end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,6 +1,2 @@
 module ReportHelper
-  # Return username in cases where user could be anonymous
-  def username(user_id)
-    User.find_by(id: user_id)&.username || "Anonymous"
-  end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -40,6 +40,12 @@ class Device < ApplicationRecord
     end
   end
 
+  def self.groups_ranked
+    Device.select('devices.*, max / (cpus * cores_per_cpu) AS max_per_core')
+          .group(:group)
+          .order(:max_per_core)
+  end
+
   def self.new_name
     colours = %w(Red Orange Yellow Green Blue Indigo Violet Pink Purple Grey)
     adjs = %w(Big Small Quick Slow Mad Calm Good Bad Brave Lucky)
@@ -50,6 +56,10 @@ class Device < ApplicationRecord
       name = "#{adjs[rand(10)]}#{colours[rand(10)]}#{animals[rand(10)]}#{rand(100)}"
     end
     name
+  end
+
+  def rank
+    Device.groups_ranked.map(&:group).find_index(self.group) + 1
   end
 
   def config_attributes

--- a/app/views/device/show.html.erb
+++ b/app/views/device/show.html.erb
@@ -7,7 +7,7 @@
 </h1>
 <p class="big-text mb-5">Entered by: <%= @device.pretty_owner %></p>
 
-<div class="d-flex mb-4">
+<div class="specs-rank-section mb-4">
   <%= render 'partials/specs_card', locals: { device: @device } %>
 
   <div class="cl-card flex-column-centred rankings-card text-center">

--- a/app/views/device/show.html.erb
+++ b/app/views/device/show.html.erb
@@ -7,38 +7,7 @@
 </h1>
 <p class="big-text mb-5">Entered by: <%= @device.pretty_owner %></p>
 
-<div class="cl-card flex-column-centred">
-  <div class="device-type-wrapper">
-    <%= image_tag "#{@device.platform_icon}.png" %>
-    <div>
-      <h4><%= @device.pretty_platform %></h4>
-      <% if @device.instance_type %>
-        <span><%= @device.instance_type %></span>
-      <% end %>
-    </div>
-  </div>
-  <div class="device-specs-wrapper <%= @device.gpus.empty? ? 'flex-column-centred' : 'device-specs-grid' %>">
-    <div class="flex-column-centred cpu">
-      <h5>CPU</h5>
-      <span><%= @device.cpus %> x <%= @device.cpu_name %></span>
-      <span>(1 x <%= @device.cores_per_cpu %> cores)</span>
-    </div>
-    <% unless @device.gpus.empty? %>
-      <div class="flex-column-centred gpu">
-        <h5>GPU</h5>
-        <span class="text-center"><%= simple_format(@device.gpu_string) %></span>
-      </div>
-    <% end %>
-    <div class="flex-column-centred ram">
-      <h5>RAM</h5>
-      <span><%= @device.ram %>GB</span>
-    </div>
-    <div class="flex-column-centred storage">
-      <h5>Storage</h5>
-      <span class="text-center"><%= simple_format(@device.disk_string) %></span>
-    </div>
-  </div>
-</div>
+<%= render 'partials/specs_card', locals: { device: @device } %>
 
 <div class="full-width-section blurred-frame flex-column-centred">
   <h2>Emissions history</h2>

--- a/app/views/device/show.html.erb
+++ b/app/views/device/show.html.erb
@@ -7,7 +7,27 @@
 </h1>
 <p class="big-text mb-5">Entered by: <%= @device.pretty_owner %></p>
 
-<%= render 'partials/specs_card', locals: { device: @device } %>
+<div class="d-flex mb-4">
+  <%= render 'partials/specs_card', locals: { device: @device } %>
+
+  <div class="cl-card flex-column-centred rankings-card text-center">
+    <h2 class="mb-4">Rankings</h2>
+    <p>
+      This server's specs and location match the
+      <a class="inline-link text-link text-nowrap" href="/group/<%= @device.group %>">
+        <strong><%= @device.pretty_group %></strong> &nbsp;
+      </a>
+      group, which is at rank
+    </p>
+    <p class="counter mb-4"><%= @device.rank %></p>
+    <p>on the OpenFlight Carbon Leaderboard.</p>
+    <%= link_to "View leaderboard",
+                leaderboard_grouped_path,
+                class: 'button glaring mt-auto'
+    %>
+  </div>
+</div>
+
 
 <div class="full-width-section blurred-frame flex-column-centred">
   <h2>Emissions history</h2>

--- a/app/views/faq/_link.html.erb
+++ b/app/views/faq/_link.html.erb
@@ -1,5 +1,5 @@
 <a
-  class="inline-link"
+  class="inline-link text-link"
   href="<%= locals[:link] %>"
   <%= 'target="_blank"' unless locals[:same_tab] %>
 >

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -16,16 +16,16 @@
     <p>Servers with these specs and location are at rank</p>
     <p class="counter mb-4"><%= dev.rank %></p>
     <p>on the OpenFlight Carbon Leaderboard.</p>
-    <%= link_to "View on leaderboard",
+    <%= link_to "View leaderboard",
                 leaderboard_grouped_path,
-                class: 'button glaring mt-auto',
-                method: :get
+                class: 'button glaring mt-auto'
     %>
   </div>
 </div>
 
 <div class="cl-card flex-column-centred server-list-card text-center mb-4">
-  <h4><%= @group.length %> servers have been entered with these specs and location</h4>
+  <% num_servers = @group.length %>
+  <h4><%= num_servers %> server<%= num_servers == 1 ? ' has' : 's have' %> been entered with these specs and location</h4>
   <div class="server-list-wrapper full-width">
     <% if @user_devices %>
       <% @user_devices.each do |user_group| %>
@@ -40,7 +40,7 @@
         <% end %>
       <% end %>
     <% end %>
-    <% if @anon_devices %>
+    <% unless @anon_devices.empty? %>
       <p class="big-text light-text mt-3 mb-2"><strong>Anonymous</strong></p>
       <% @anon_devices.each do |device_name| %>
         <%= link_to device_name,

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -40,10 +40,23 @@
         <span>miles</span>
       </div>
     </div>
-    <i class="fa-solid fa-car-side car-icon"></i>
+    <i class="fa-solid fa-car-side big-icon"></i>
   </div>
   <div class="blurred-frame white-outline"></div>
-  <div class="blurred-frame white-outline"></div>
+  <div class="blurred-frame white-outline emission-wrapper">
+    <div class="flight-wrapper">
+      <div class="people-plane">
+        <div class="people mt-auto">
+          <span>...</span>
+          <span class="emission-number">4</span>
+          <br>
+          <span>people</span>
+        </div>
+        <i class="fa-solid fa-plane big-icon plane-icon"></i>
+      </div>
+      <span class="big-text">flying from <br>London to Hamburg</span>
+    </div>
+  </div>
 </div>
 
 <div class="cl-card flex-column-centred server-list-card text-center mb-4">

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -40,7 +40,9 @@
         <span>miles</span>
       </div>
     </div>
-    <i class="fa-solid fa-car-side big-icon"></i>
+    <div class="driving-icon-wrapper">
+      <i class="fa-solid fa-car-side big-icon driving-icon"></i>
+    </div>
   </div>
   <div class="blurred-frame white-outline emission-wrapper">
     <div class="burger-wrapper">
@@ -53,7 +55,7 @@
         <span class="big-text">Big Macs...</span>
       </div>
     </div>
-    <span class="mcplant">
+    <span class="mcplant mt-2">
       ...or
       <span class="emission-number">
         <%= @emission_conversions[:mcplant] %>
@@ -63,18 +65,29 @@
     </div>
   </div>
   <div class="blurred-frame white-outline emission-wrapper">
-    <div class="flight-wrapper">
-      <div class="people-plane">
-        <div class="people mt-auto">
-          <span>...</span>
-          <span class="emission-number"><%= @emission_conversions[:flight] %></span>
-          <br>
-          <span>people</span>
+    <% if @emission_conversions[:flight] > 0 %>
+      <div class="flight-wrapper">
+        <div class="people-plane">
+          <div class="people mt-auto">
+            <span>...</span>
+            <span class="emission-number"><%= @emission_conversions[:flight] %></span>
+            <br>
+            <span>people</span>
+          </div>
+          <i class="fa-solid fa-plane big-icon plane-icon"></i>
         </div>
-        <i class="fa-solid fa-plane big-icon plane-icon"></i>
+        <span class="big-text">flying from <br>London to Hamburg</span>
       </div>
-      <span class="big-text">flying from <br>London to Hamburg</span>
-    </div>
+    <% else %>
+      <div class="netflix-wrapper">
+        <span class="big-text mb-2">...streaming Netflix for</span>
+        <i class="fa-solid fa-tv big-icon netflix-icon"></i>
+        <div class="mt-2">
+          <span class="emission-number"><%= @emission_conversions[:netflix] %></span>
+          <span>hours</span>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -9,7 +9,8 @@ td {
   text-align: center;
 }
 </style>
-<h4><%= @group.length %> device<%= 's' * [1, @group.length - 1].min %> in this group</h4>
+
+<h4>Devices in group</h4>
 <table style="width:100%" align="right">
   <tr>
     <th>Device Name</th>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -37,7 +37,7 @@
       <div class="miles">
         <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:driving], delimiter: ',') %></span>
         <br>
-        <span>miles</span>
+        <span>mile<%= 's' unless @emission_conversions[:driving] == 1 %></span>
       </div>
     </div>
     <div class="driving-icon-wrapper">
@@ -52,7 +52,7 @@
           <span class="big-text">...making</span><br>
           <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:big_mac], delimiter: ',') %></span><br>
           <span class="big-text">McDonalds</span><br>
-          <span class="big-text">Big Macs...</span>
+          <span class="big-text">Big Mac<%= 's' unless @emission_conversions[:big_mac] == 1 %>...</span>
         </div>
       </div>
       <span class="mcplant mt-2">
@@ -60,7 +60,7 @@
       <span class="emission-number">
         <%= number_with_delimiter(@emission_conversions[:mcplant], delimiter: ',') %>
       </span>
-      McPlants
+      McPlant<%= 's' unless @emission_conversions[:mcplant] == 1 %>
     </span>
     </div>
   </div>
@@ -72,7 +72,7 @@
             <span>...</span>
             <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:flight], delimiter: ',') %></span>
             <br>
-            <span>people</span>
+            <span><%= @emission_conversions[:flight] == 1 ? 'person' : 'people' %></span>
           </div>
           <i class="fa-solid fa-plane big-icon plane-icon"></i>
         </div>
@@ -84,7 +84,7 @@
         <i class="fa-solid fa-tv big-icon netflix-icon"></i>
         <div class="mt-2">
           <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:netflix], delimiter: ',') %></span>
-          <span>hours</span>
+          <span>hour<%= 's' unless @emission_conversions[:netflix] == 1 %></span>
         </div>
       </div>
     <% end %>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -27,7 +27,7 @@
   <div class="text-center">
     <h2 class="mb-4">Emissions</h2>
     <p>Over one year, running at full load, servers in this group will emit</p>
-    <p class="emission-number">2.8kg</p>
+    <p class="emission-number"><%= @year_emissions %>kg</p>
     <p>equivalent CO<sub>2</sub>. That’s as much as...</p>
   </div>
 
@@ -35,7 +35,7 @@
     <div class="driving-wrapper">
       <span class="driving">...driving</span>
       <div class="miles">
-        <span class="emission-number">48</span>
+        <span class="emission-number"><%= @emission_conversions[:driving] %></span>
         <br>
         <span>miles</span>
       </div>
@@ -48,12 +48,18 @@
       <i class="fa-solid fa-burger big-icon"></i>
       <div>
         <span class="big-text">...making</span><br>
-        <span class="emission-number">100</span><br>
+        <span class="emission-number"><%= @emission_conversions[:big_mac] %></span><br>
         <span class="big-text">McDonalds</span><br>
         <span class="big-text">Big Macs...</span>
       </div>
     </div>
-    <span class="mcplant">...or <span class="emission-number">13</span> McPlants</span>
+    <span class="mcplant">
+      ...or
+      <span class="emission-number">
+        <%= @emission_conversions[:mcplant] %>
+      </span>
+      McPlants
+    </span>
     </div>
   </div>
   <div class="blurred-frame white-outline emission-wrapper">
@@ -61,7 +67,7 @@
       <div class="people-plane">
         <div class="people mt-auto">
           <span>...</span>
-          <span class="emission-number">4</span>
+          <span class="emission-number"><%= @emission_conversions[:flight] %></span>
           <br>
           <span>people</span>
         </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -35,7 +35,7 @@
     <div class="driving-wrapper">
       <span class="driving">...driving</span>
       <div class="miles">
-        <span class="emission-number"><%= @emission_conversions[:driving] %></span>
+        <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:driving], delimiter: ',') %></span>
         <br>
         <span>miles</span>
       </div>
@@ -50,7 +50,7 @@
       <i class="fa-solid fa-burger big-icon"></i>
       <div>
         <span class="big-text">...making</span><br>
-        <span class="emission-number"><%= @emission_conversions[:big_mac] %></span><br>
+        <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:big_mac], delimiter: ',') %></span><br>
         <span class="big-text">McDonalds</span><br>
         <span class="big-text">Big Macs...</span>
       </div>
@@ -58,7 +58,7 @@
     <span class="mcplant mt-2">
       ...or
       <span class="emission-number">
-        <%= @emission_conversions[:mcplant] %>
+        <%= number_with_delimiter(@emission_conversions[:mcplant], delimiter: ',') %>
       </span>
       McPlants
     </span>
@@ -70,7 +70,7 @@
         <div class="people-plane">
           <div class="people mt-auto">
             <span>...</span>
-            <span class="emission-number"><%= @emission_conversions[:flight] %></span>
+            <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:flight], delimiter: ',') %></span>
             <br>
             <span>people</span>
           </div>
@@ -83,7 +83,7 @@
         <span class="big-text mb-2">...streaming Netflix for</span>
         <i class="fa-solid fa-tv big-icon netflix-icon"></i>
         <div class="mt-2">
-          <span class="emission-number"><%= @emission_conversions[:netflix] %></span>
+          <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:netflix], delimiter: ',') %></span>
           <span>hours</span>
         </div>
       </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -40,7 +40,7 @@
         <span>miles</span>
       </div>
     </div>
-
+    <i class="fa-solid fa-car-side car-icon"></i>
   </div>
   <div class="blurred-frame white-outline"></div>
   <div class="blurred-frame white-outline"></div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -23,8 +23,17 @@
   </div>
 </div>
 
-<div class="cl-card d-flex full-width mb-4">
-  <h2 class="mb-4">Emissions</h2>
+<div class="cl-card full-width emissions-wrapper mb-4">
+  <div class="text-center">
+    <h2 class="mb-4">Emissions</h2>
+    <p>Over one year, running at full load, servers in this group will emit</p>
+    <p class="emission-number">2.8kg</p>
+    <p>equivalent CO<sub>2</sub>. That’s as much as...</p>
+  </div>
+
+  <div class="blurred-frame white-outline"></div>
+  <div class="blurred-frame white-outline"></div>
+  <div class="blurred-frame white-outline"></div>
 </div>
 
 <div class="cl-card flex-column-centred server-list-card text-center mb-4">

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -8,7 +8,7 @@
   </span>
 </h1>
 
-<div class="d-flex mb-4">
+<div class="full-width specs-rank-section mb-4">
   <%= render 'partials/specs_card', locals: { device: dev } %>
 
   <div class="cl-card flex-column-centred text-center rankings-card">
@@ -21,6 +21,10 @@
                 class: 'button glaring mt-auto'
     %>
   </div>
+</div>
+
+<div class="cl-card d-flex full-width mb-4">
+  <h2 class="mb-4">Emissions</h2>
 </div>
 
 <div class="cl-card flex-column-centred server-list-card text-center mb-4">

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -4,38 +4,50 @@
   <%= dev.pretty_group %>
   <span
     class="flag server-page fi fi-<%= dev.two_digit_location.downcase %> fis"
-    title="<%= dev.display_name %> is located in <%= dev.full_country_name %>">
+    title="<%= dev.pretty_group %> is located in <%= dev.full_country_name %>">
   </span>
 </h1>
 
-<div class="d-flex">
+<div class="d-flex mb-4">
   <%= render 'partials/specs_card', locals: { device: dev } %>
 
-  <div class="cl-card flex-column-centred server-list-card text-center">
-    <h4><%= @group.length %> servers have been entered with these specs and location</h4>
-    <div class="server-list-wrapper full-width">
-      <% if @user_devices %>
-        <% @user_devices.each do |user_group| %>
-          <a class="text-link mt-3 mb-2" href="/user/<%= user_group[0] %>">
-            <strong class="big-text"><%= current_user&.username == user_group[0] ? 'My servers' : user_group[0] %></strong>
-          </a>
-          <% user_group[1].each do |device_name| %>
-            <%= link_to device_name,
-                        "/device/#{device_name}",
-                        class: "server-in-list blurred-frame white-outline full-width mb-2"
-            %>
-          <% end %>
-        <% end %>
-      <% end %>
-      <% if @anon_devices %>
-        <p class="big-text light-text mt-3 mb-2"><strong>Anonymous</strong></p>
-        <% @anon_devices.each do |device_name| %>
+  <div class="cl-card flex-column-centred text-center">
+    <h2 class="mb-4">Rankings</h2>
+    <p>Servers with these specs and location are at rank</p>
+    <p class="counter mb-4"><%= 1 %></p>
+    <p>on the OpenFlight Carbon Leaderboard.</p>
+    <%= link_to "View on leaderboard",
+                leaderboard_grouped_path,
+                class: 'button glaring mt-auto',
+                method: :get
+    %>
+  </div>
+</div>
+
+<div class="cl-card flex-column-centred server-list-card text-center mb-4">
+  <h4><%= @group.length %> servers have been entered with these specs and location</h4>
+  <div class="server-list-wrapper full-width">
+    <% if @user_devices %>
+      <% @user_devices.each do |user_group| %>
+        <a class="text-link mt-3 mb-2" href="/user/<%= user_group[0] %>">
+          <strong class="big-text"><%= current_user&.username == user_group[0] ? 'My servers' : user_group[0] %></strong>
+        </a>
+        <% user_group[1].each do |device_name| %>
           <%= link_to device_name,
                       "/device/#{device_name}",
                       class: "server-in-list blurred-frame white-outline full-width mb-2"
           %>
         <% end %>
       <% end %>
-    </div>
+    <% end %>
+    <% if @anon_devices %>
+      <p class="big-text light-text mt-3 mb-2"><strong>Anonymous</strong></p>
+      <% @anon_devices.each do |device_name| %>
+        <%= link_to device_name,
+                    "/device/#{device_name}",
+                    class: "server-in-list blurred-frame white-outline full-width mb-2"
+        %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -46,16 +46,16 @@
   </div>
   <div class="blurred-frame white-outline emission-wrapper">
     <div class="burger-wrapper">
-    <div class="big-mac-wrapper">
-      <i class="fa-solid fa-burger big-icon"></i>
-      <div>
-        <span class="big-text">...making</span><br>
-        <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:big_mac], delimiter: ',') %></span><br>
-        <span class="big-text">McDonalds</span><br>
-        <span class="big-text">Big Macs...</span>
+      <div class="big-mac-wrapper">
+        <i class="fa-solid fa-burger big-icon"></i>
+        <div>
+          <span class="big-text">...making</span><br>
+          <span class="emission-number"><%= number_with_delimiter(@emission_conversions[:big_mac], delimiter: ',') %></span><br>
+          <span class="big-text">McDonalds</span><br>
+          <span class="big-text">Big Macs...</span>
+        </div>
       </div>
-    </div>
-    <span class="mcplant mt-2">
+      <span class="mcplant mt-2">
       ...or
       <span class="emission-number">
         <%= number_with_delimiter(@emission_conversions[:mcplant], delimiter: ',') %>
@@ -93,8 +93,9 @@
 
 <div class="cl-card flex-column-centred server-list-card text-center mb-4">
   <% num_servers = @group.length %>
-  <h4><%= num_servers %> server<%= num_servers == 1 ? ' has' : 's have' %> been entered with these specs and location</h4>
-  <div class="server-list-wrapper full-width">
+  <h4><%= num_servers %> server<%= num_servers == 1 ? ' has' : 's have' %> been entered with these specs and
+    location</h4>
+  <div class="server-list-wrapper">
     <% if @user_devices %>
       <% @user_devices.each do |user_group| %>
         <a class="text-link mt-3 mb-2" href="/user/<%= user_group[0] %>">
@@ -103,7 +104,7 @@
         <% user_group[1].each do |device_name| %>
           <%= link_to device_name,
                       "/device/#{device_name}",
-                      class: "server-in-list blurred-frame white-outline full-width mb-2"
+                      class: "server-in-list glaring"
           %>
         <% end %>
       <% end %>
@@ -113,7 +114,7 @@
       <% @anon_devices.each do |device_name| %>
         <%= link_to device_name,
                     "/device/#{device_name}",
-                    class: "server-in-list blurred-frame white-outline full-width mb-2"
+                    class: "server-in-list glaring"
         %>
       <% end %>
     <% end %>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -11,14 +11,30 @@
 <div class="d-flex">
   <%= render 'partials/specs_card', locals: { device: dev } %>
 
-  <div class="cl-card flex-column-centred server-list-card">
-    <h3 class="mb-4">In this group...</h3>
+  <div class="cl-card flex-column-centred server-list-card text-center">
+    <h4><%= @group.length %> servers have been entered with these specs and location</h4>
     <div class="server-list-wrapper full-width">
-      <% @group.each do |device| %>
-        <%= link_to device.display_name,
-                    "/device/#{device.display_name}",
-                    class: "server-in-list blurred-frame white-outline full-width big-text mb-2"
-        %>
+      <% if @user_devices %>
+        <% @user_devices.each do |user_group| %>
+          <a class="text-link mt-3 mb-2" href="/user/<%= user_group[0] %>">
+            <strong class="big-text"><%= current_user&.username == user_group[0] ? 'My servers' : user_group[0] %></strong>
+          </a>
+          <% user_group[1].each do |device_name| %>
+            <%= link_to device_name,
+                        "/device/#{device_name}",
+                        class: "server-in-list blurred-frame white-outline full-width mb-2"
+            %>
+          <% end %>
+        <% end %>
+      <% end %>
+      <% if @anon_devices %>
+        <p class="big-text light-text mt-3 mb-2"><strong>Anonymous</strong></p>
+        <% @anon_devices.each do |device_name| %>
+          <%= link_to device_name,
+                      "/device/#{device_name}",
+                      class: "server-in-list blurred-frame white-outline full-width mb-2"
+          %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -45,9 +45,7 @@
   <div class="cl-card flex-column-centred">
     <h3 class="mb-4">Servers in this group</h3>
     <% @group.each do |device| %>
-      <p>
-        <%= link_to device.display_name, "/device/#{device.display_name}" %>
-      </p>
+        <%= link_to device.display_name, "/device/#{device.display_name}", class: "server-in-list blurred-frame white-outline full-width big-text" %>
     <% end %>
   </div>
 </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -42,7 +42,20 @@
     </div>
     <i class="fa-solid fa-car-side big-icon"></i>
   </div>
-  <div class="blurred-frame white-outline"></div>
+  <div class="blurred-frame white-outline emission-wrapper">
+    <div class="burger-wrapper">
+    <div class="big-mac-wrapper">
+      <i class="fa-solid fa-burger big-icon"></i>
+      <div>
+        <span class="big-text">...making</span><br>
+        <span class="emission-number">100</span><br>
+        <span class="big-text">McDonalds</span><br>
+        <span class="big-text">Big Macs...</span>
+      </div>
+    </div>
+    <span class="mcplant">...or <span class="emission-number">13</span> McPlants</span>
+    </div>
+  </div>
   <div class="blurred-frame white-outline emission-wrapper">
     <div class="flight-wrapper">
       <div class="people-plane">

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -44,8 +44,13 @@
 
   <div class="cl-card flex-column-centred">
     <h3 class="mb-4">Servers in this group</h3>
-    <% @group.each do |device| %>
-        <%= link_to device.display_name, "/device/#{device.display_name}", class: "server-in-list blurred-frame white-outline full-width big-text" %>
-    <% end %>
+    <div class="server-list-wrapper full-width">
+      <% @group.each do |device| %>
+        <%= link_to device.display_name,
+                    "/device/#{device.display_name}",
+                    class: "server-in-list blurred-frame white-outline full-width big-text mb-2"
+        %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -11,7 +11,7 @@
 <div class="d-flex mb-4">
   <%= render 'partials/specs_card', locals: { device: dev } %>
 
-  <div class="cl-card flex-column-centred text-center">
+  <div class="cl-card flex-column-centred text-center rankings-card">
     <h2 class="mb-4">Rankings</h2>
     <p>Servers with these specs and location are at rank</p>
     <p class="counter mb-4"><%= dev.rank %></p>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -9,38 +9,7 @@
 </h1>
 
 <div class="d-flex">
-  <div class="cl-card flex-column-centred mx-3">
-    <div class="device-type-wrapper">
-      <%= image_tag "logo.svg" %>
-      <div>
-        <h4><%= dev.platform.capitalize %></h4>
-        <% if dev.instance_type %>
-          <span>instance-type<%= dev.instance_type %></span>
-        <% end %>
-      </div>
-    </div>
-    <div class="device-specs-wrapper <%= dev.gpus.empty? ? 'flex-column-centred' : 'device-specs-grid' %>">
-      <div class="flex-column-centred cpu">
-        <h5>CPU</h5>
-        <span><%= dev.cpus %> x <%= dev.cpu_name %></span>
-        <span>(1 x <%= dev.cores_per_cpu %> cores)</span>
-      </div>
-      <% unless dev.gpus.empty? %>
-        <div class="flex-column-centred gpu">
-          <h5>GPU</h5>
-          <span class="text-center"><%= simple_format(dev.gpu_string) %></span>
-        </div>
-      <% end %>
-      <div class="flex-column-centred ram">
-        <h5>RAM</h5>
-        <span><%= dev.ram %>GB</span>
-      </div>
-      <div class="flex-column-centred storage">
-        <h5>Storage</h5>
-        <span class="text-center"><%= simple_format(dev.disk_string) %></span>
-      </div>
-    </div>
-  </div>
+  <%= render 'partials/specs_card', locals: { device: dev } %>
 
   <div class="cl-card flex-column-centred server-list-card">
     <h3 class="mb-4">In this group...</h3>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -31,7 +31,17 @@
     <p>equivalent CO<sub>2</sub>. That’s as much as...</p>
   </div>
 
-  <div class="blurred-frame white-outline"></div>
+  <div class="blurred-frame white-outline emission-wrapper">
+    <div class="driving-wrapper">
+      <span class="driving">...driving</span>
+      <div class="miles">
+        <span class="emission-number">48</span>
+        <br>
+        <span>miles</span>
+      </div>
+    </div>
+
+  </div>
   <div class="blurred-frame white-outline"></div>
   <div class="blurred-frame white-outline"></div>
 </div>

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -76,7 +76,7 @@
           </div>
           <i class="fa-solid fa-plane big-icon plane-icon"></i>
         </div>
-        <span class="big-text">flying from <br>London to Hamburg</span>
+        <span class="big-text mt-2">flying from <br>London to Hamburg</span>
       </div>
     <% else %>
       <div class="netflix-wrapper">

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -42,8 +42,8 @@
     </div>
   </div>
 
-  <div class="cl-card flex-column-centred">
-    <h3 class="mb-4">Servers in this group</h3>
+  <div class="cl-card flex-column-centred server-list-card">
+    <h3 class="mb-4">In this group...</h3>
     <div class="server-list-wrapper full-width">
       <% @group.each do |device| %>
         <%= link_to device.display_name,

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -14,7 +14,7 @@
   <div class="cl-card flex-column-centred text-center">
     <h2 class="mb-4">Rankings</h2>
     <p>Servers with these specs and location are at rank</p>
-    <p class="counter mb-4"><%= 1 %></p>
+    <p class="counter mb-4"><%= dev.rank %></p>
     <p>on the OpenFlight Carbon Leaderboard.</p>
     <%= link_to "View on leaderboard",
                 leaderboard_grouped_path,

--- a/app/views/group/show.html.erb
+++ b/app/views/group/show.html.erb
@@ -1,31 +1,53 @@
 <% dev = @group.first %>
-<h1>Group Information for <%= dev.pretty_group %></h1>
 
-<style>
-table, th, td {
-  border:1px solid black;
-}
-td {
-  text-align: center;
-}
-</style>
+<h1 class="mb-5">
+  <%= dev.pretty_group %>
+  <span
+    class="flag server-page fi fi-<%= dev.two_digit_location.downcase %> fis"
+    title="<%= dev.display_name %> is located in <%= dev.full_country_name %>">
+  </span>
+</h1>
 
-<h4>Devices in group</h4>
-<table style="width:100%" align="right">
-  <tr>
-    <th>Device Name</th>
-    <th>Owner</th>
-  </tr>
-  <% @group.each do |device| %>
-    <tr>
-      <td>
-        <a href="/device/<%= device.display_name %>">
-          <%= device.display_name %>
-        </a>
-      </td>
-      <td><%= username(device.user_id) %></td>
-    </tr>
-  <% end %>
-</table>
+<div class="d-flex">
+  <div class="cl-card flex-column-centred mx-3">
+    <div class="device-type-wrapper">
+      <%= image_tag "logo.svg" %>
+      <div>
+        <h4><%= dev.platform.capitalize %></h4>
+        <% if dev.instance_type %>
+          <span>instance-type<%= dev.instance_type %></span>
+        <% end %>
+      </div>
+    </div>
+    <div class="device-specs-wrapper <%= dev.gpus.empty? ? 'flex-column-centred' : 'device-specs-grid' %>">
+      <div class="flex-column-centred cpu">
+        <h5>CPU</h5>
+        <span><%= dev.cpus %> x <%= dev.cpu_name %></span>
+        <span>(1 x <%= dev.cores_per_cpu %> cores)</span>
+      </div>
+      <% unless dev.gpus.empty? %>
+        <div class="flex-column-centred gpu">
+          <h5>GPU</h5>
+          <span class="text-center"><%= simple_format(dev.gpu_string) %></span>
+        </div>
+      <% end %>
+      <div class="flex-column-centred ram">
+        <h5>RAM</h5>
+        <span><%= dev.ram %>GB</span>
+      </div>
+      <div class="flex-column-centred storage">
+        <h5>Storage</h5>
+        <span class="text-center"><%= simple_format(dev.disk_string) %></span>
+      </div>
+    </div>
+  </div>
 
-
+  <div class="cl-card flex-column-centred">
+    <h3 class="mb-4">Servers in this group</h3>
+    <% @group.each do |device| %>
+      <p>
+        <%= link_to device.display_name, "/device/#{device.display_name}" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <%= javascript_importmap_tags %>
     <script type="text/javascript" src="/assets/bezier_generator.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <script src="https://kit.fontawesome.com/5d76af6daa.js" crossorigin="anonymous"></script>
   </head>
 
   <body>

--- a/app/views/partials/_specs_card.html.erb
+++ b/app/views/partials/_specs_card.html.erb
@@ -1,5 +1,5 @@
 <% device = locals[:device] %>
-<div class="cl-card flex-column-centred mx-3">
+<div class="cl-card flex-column-centred mr-4">
   <div class="device-type-wrapper">
     <%= image_tag "#{device.platform_icon}.png" %>
     <div>

--- a/app/views/partials/_specs_card.html.erb
+++ b/app/views/partials/_specs_card.html.erb
@@ -1,0 +1,33 @@
+<% device = locals[:device] %>
+<div class="cl-card flex-column-centred mx-3">
+  <div class="device-type-wrapper">
+    <%= image_tag "#{device.platform_icon}.png" %>
+    <div>
+      <h4><%= device.pretty_platform %></h4>
+      <% if device.instance_type %>
+        <span><%= device.instance_type %></span>
+      <% end %>
+    </div>
+  </div>
+  <div class="device-specs-wrapper <%= device.gpus.empty? ? 'flex-column-centred' : 'device-specs-grid' %>">
+    <div class="flex-column-centred cpu">
+      <h5>CPU</h5>
+      <span><%= device.cpus %> x <%= device.cpu_name %></span>
+      <span>(1 x <%= device.cores_per_cpu %> cores)</span>
+    </div>
+    <% unless device.gpus.empty? %>
+      <div class="flex-column-centred gpu">
+        <h5>GPU</h5>
+        <span class="text-center"><%= simple_format(device.gpu_string) %></span>
+      </div>
+    <% end %>
+    <div class="flex-column-centred ram">
+      <h5>RAM</h5>
+      <span><%= device.ram %>GB</span>
+    </div>
+    <div class="flex-column-centred storage">
+      <h5>Storage</h5>
+      <span class="text-center"><%= simple_format(device.disk_string) %></span>
+    </div>
+  </div>
+</div>

--- a/app/views/partials/_specs_card.html.erb
+++ b/app/views/partials/_specs_card.html.erb
@@ -3,7 +3,7 @@
   <div class="device-type-wrapper">
     <%= image_tag "#{device.platform_icon}.png" %>
     <div>
-      <h4><%= device.pretty_platform %></h4>
+      <h2 class="mb-0"><%= device.pretty_platform %></h2>
       <% if device.instance_type %>
         <span><%= device.instance_type %></span>
       <% end %>

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -1,7 +1,23 @@
-<h1><%= "Profile page for #{username(@user&.id)}" %></h1>
+<h1 class="mb-5 pb-1"><%= @user.username %></h1>
 
-<p>
-<%= "This is the user profile page for #{username(@user&.id)}."%>
-</p>
+<% if @user_owns_profile %>
+  <p>
+    Here's your secret Auth token:
+  </p>
+  <p class="mb-5">
+    <%= @user.auth_token %>
+  </p>
+<% end %>
 
-<%= "Since this is your page, here's your secret Auth token: #{@user.auth_token}" if @user_owns_profile%>
+<% unless @devices.empty? %>
+  <h4 class="mb-4"><%= @user_owns_profile ? 'My' : "#{@user.username}'s" %> nodes</h4>
+
+  <% @devices.each do |device| %>
+    <p>
+      <%= link_to device.display_name, "/device/#{device.display_name}" %>
+    </p>
+  <% end %>
+<% end %>
+
+
+

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -19,11 +19,11 @@
     <a class="inline-link text-link" href="/group/<%= dev.group %>">
       <h4 class="mb-3"><%= "#{dev.platform}-#{dev.instance_type || "Group#{dev.group}"}-#{dev.location}" %></h4>
     </a>
-    <div class="server-list-wrapper med-card flex-column-centred mb-4">
+    <div class="server-list-wrapper mb-4">
     <% group_devices.each do |device| %>
-      <%= link_to device.display_name,
-                  "/device/#{device.display_name}",
-                  class: "server-in-list blurred-frame white-outline med-card big-text mb-2"
+        <%= link_to device.display_name,
+                    "/device/#{device.display_name}",
+                    class: "server-in-list glaring"
       %>
     <% end %>
     </div>

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -16,7 +16,9 @@
   <% @groups.each do |group| %>
     <% group_devices = @devices.where(group: group) %>
     <% dev = group_devices.first %>
-    <h4 class="mb-3"><%= "#{dev.platform}-#{dev.instance_type || "Group#{dev.group}"}-#{dev.location}" %></h4>
+    <a class="inline-link" href="/group/<%= dev.group %>">
+      <h4 class="mb-3"><%= "#{dev.platform}-#{dev.instance_type || "Group#{dev.group}"}-#{dev.location}" %></h4>
+    </a>
     <div class="server-list-wrapper med-card flex-column-centred mb-4">
     <% group_devices.each do |device| %>
       <%= link_to device.display_name,

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -9,15 +9,13 @@
   </p>
 <% end %>
 
-<% unless @devices.empty? %>
-  <h4 class="mb-4"><%= @user_owns_profile ? 'My' : "#{@user.username}'s" %> nodes</h4>
-
+<h4 class="mb-4"><%= @user_owns_profile ? 'My' : "#{@user.username}'s" %> servers</h4>
+<% if @devices.empty? %>
+  <%= @user_owns_profile ? "You haven't" : "#{@user.username} hasn't" %> entered any servers yet.
+<% else %>
   <% @devices.each do |device| %>
     <p>
       <%= link_to device.display_name, "/device/#{device.display_name}" %>
     </p>
   <% end %>
 <% end %>
-
-
-

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -9,13 +9,21 @@
   </p>
 <% end %>
 
-<h4 class="mb-4"><%= @user_owns_profile ? 'My' : "#{@user.username}'s" %> servers</h4>
+<h2 class="mb-4"><%= @user_owns_profile ? 'My' : "#{@user.username}'s" %> servers</h2>
 <% if @devices.empty? %>
   <%= @user_owns_profile ? "You haven't" : "#{@user.username} hasn't" %> entered any servers yet.
 <% else %>
-  <% @devices.each do |device| %>
-    <p>
-      <%= link_to device.display_name, "/device/#{device.display_name}" %>
-    </p>
+  <% @groups.each do |group| %>
+    <% group_devices = @devices.where(group: group) %>
+    <% dev = group_devices.first %>
+    <h4 class="mb-3"><%= "#{dev.platform}-#{dev.instance_type || "Group#{dev.group}"}-#{dev.location}" %></h4>
+    <div class="server-list-wrapper med-card flex-column-centred mb-4">
+    <% group_devices.each do |device| %>
+      <%= link_to device.display_name,
+                  "/device/#{device.display_name}",
+                  class: "server-in-list blurred-frame white-outline med-card big-text mb-2"
+      %>
+    <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -16,7 +16,7 @@
   <% @groups.each do |group| %>
     <% group_devices = @devices.where(group: group) %>
     <% dev = group_devices.first %>
-    <a class="inline-link" href="/group/<%= dev.group %>">
+    <a class="inline-link text-link" href="/group/<%= dev.group %>">
       <h4 class="mb-3"><%= "#{dev.platform}-#{dev.instance_type || "Group#{dev.group}"}-#{dev.location}" %></h4>
     </a>
     <div class="server-list-wrapper med-card flex-column-centred mb-4">

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -5,7 +5,7 @@
     Here's your secret Auth token:
   </p>
   <p class="mb-5">
-    <%= @user.auth_token %>
+    <code class="code-block"><%= @user.auth_token %></code>
   </p>
 <% end %>
 

--- a/app/views/user/profile.html.erb
+++ b/app/views/user/profile.html.erb
@@ -13,19 +13,34 @@
 <% if @devices.empty? %>
   <%= @user_owns_profile ? "You haven't" : "#{@user.username} hasn't" %> entered any servers yet.
 <% else %>
-  <% @groups.each do |group| %>
-    <% group_devices = @devices.where(group: group) %>
+  <% @groups.each do |group_id| %>
+    <% group_devices = @devices.where(group: group_id) %>
     <% dev = group_devices.first %>
-    <a class="inline-link text-link" href="/group/<%= dev.group %>">
-      <h4 class="mb-3"><%= "#{dev.platform}-#{dev.instance_type || "Group#{dev.group}"}-#{dev.location}" %></h4>
-    </a>
+    <% rank = dev.rank %>
+    <div class="home-leaderboard leaderboard-wrapper mt-4">
+      <div class="leaderboard-content-wrapper">
+        <a href="/group/<%= group_id %>">
+          <div class="leaderboard-item-wrapper blurred-frame mb-3 <%= rank <= 3 ? "rank-#{rank}" : "solid-rank" %>">
+            <div class="leaderboard-item glare"></div>
+            <div class="leaderboard-item rank-column"><%= rank %></div>
+            <div class="group-name">
+              <span class="big-text"><%= dev.pretty_group %></span><br>
+              <span><%= "#{group_devices.length} server#{'s' if group_devices.length > 1}" %></span>
+            </div>
+            <div></div>
+            <div><span class="flag fi fi-<%= dev.two_digit_location.downcase %> fis"></span></div>
+          </div>
+
+        </a>
+      </div>
+    </div>
     <div class="server-list-wrapper mb-4">
-    <% group_devices.each do |device| %>
+      <% group_devices.each do |device| %>
         <%= link_to device.display_name,
                     "/device/#{device.display_name}",
                     class: "server-in-list glaring"
-      %>
-    <% end %>
+        %>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   get "/leaderboard/grouped",            to: "group#index"
   post "/add-record",                    to: "report#add_record"
-
+  
   get "/leaderboard/raw-data/:unit",     to: "device#raw_data"
   get "/device/:device",                 to: "device#show"
   post "/add-tag/:device",               to: "device#add_tag"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,16 +2,14 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { sessions: "users/sessions", registrations: "users/registrations" }
   root "home#index"
 
-  get "/leaderboard/grouped",            to: "group#index"
   post "/add-record",                    to: "report#add_record"
 
-  get "/show-devices",                   to: "device#index"
-  get "/leaderboard/raw-data/:unit",     to: "device#raw_data"
   get "/device/:device",                 to: "device#show"
   post "/add-tag/:device",               to: "device#add_tag"
   post "/delete-tag/:device",            to: "device#delete_tag"
 
   get "/group/:group_id",                to: "group#show"
+  get "/leaderboard/grouped",            to: "group#index"
   get "/leaderboard/grouped-data/:unit", to: "group#raw_data"
 
   get "/user/:username",                 to: "user#profile"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
 
   get "/leaderboard/grouped",            to: "group#index"
   post "/add-record",                    to: "report#add_record"
-  
+
+  get "/show-devices",                   to: "device#index"
   get "/leaderboard/raw-data/:unit",     to: "device#raw_data"
   get "/device/:device",                 to: "device#show"
   post "/add-tag/:device",               to: "device#add_tag"

--- a/lib/emission_conversion.rb
+++ b/lib/emission_conversion.rb
@@ -13,5 +13,3 @@ class EmissionConversion
   NETFLIX = 55.556      # Episodes streamed on Netflix (30mins each)
   EMAIL = 250           # Emails sent
 end
-
-

--- a/lib/emission_conversion.rb
+++ b/lib/emission_conversion.rb
@@ -10,6 +10,6 @@ class EmissionConversion
   MCPLANT = 3.4483      # McPlants made
   DRIVE = 3.4872        # Miles driven in an average car
   COFFEES = 18.868      # Cups of coffee (with milk, boiling only the water needed)
-  NETFLIX = 55.556      # Episodes streamed on Netflix (30mins each)
+  NETFLIX = 27.778      # Hours of content streamed on Netflix
   EMAIL = 250           # Emails sent
 end


### PR DESCRIPTION
### Improvements to the group page

- Adds a card showing the specs of devices in the group, matching the specs card on the server pages
- Adds a 'Rankings' card showing the group's rank on the leaderboard
- Emission conversions have been added, comparing yearly emissions by servers in the group to miles driven, burgers made and either people flown from London to Hamburg or hours of Netflix streamed (dependent on whether emissions are high enough to reach one person flown)
- A list of servers in the group are shown, broken down by user. The username is a link to the user's profile. Anonymously submitted servers are shown at the bottom.

![image](https://github.com/openflighthpc/carbon-leaderboard/assets/102584263/3be92d47-9c7a-4bed-b16c-1646a8b3ff1f)
![image](https://github.com/openflighthpc/carbon-leaderboard/assets/102584263/681562b8-1afa-4e89-af3f-f88392cac485)

### Collateral improvements

- A similar 'Rankings' card has been added to individual server pages
- A list of servers has been added to the user profile page, broken down by group, where each group name links to the respective group page

![image](https://github.com/openflighthpc/carbon-leaderboard/assets/102584263/749512ff-26b3-40cb-811c-1208b44c06c8)

### Future improvements

It would be nice to have a link to see a given group on the leaderboard, e.g. if a group is at rank 37, go to the leaderboard and show the group at that rank. I was planning to implement that here, but it ended up being a bit awkward as the leaderboard entries are added after page load
