### PR TITLE
Take ownership of anonymous devices

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -7,7 +7,10 @@ class ReportController < ApplicationController
     data = JSON.parse(request.body.read)
     device = Device.find_by(uuid: data['device_id'])
 
-    unless device
+    if device
+      device.user_id = device.user_id || @current_user.id
+      device.save
+    else
       device = Device.create_from_json(data, @current_user) unless device
       if !device.errors.empty?
         render json: "Error(s) with payload data: #{device.errors.full_messages.join(', ')}"


### PR DESCRIPTION
This small PR introduces the ability to "claim" a device - if you uploaded a device anonymously, then later create an account and use your token to run `carbon send` from the same device, your account will be set as the owner for that device.

A device may only be "claimed" if the owner was previously `Anonymous`, i.e. its `user_id` field was `nil`.