### PR TITLE
Fix profile ranks

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -59,8 +59,13 @@ class Device < ApplicationRecord
     name
   end
 
+  def max_per_core
+    self.max / (self.cpus * self.cores_per_cpu)
+  end
+
   def rank
-    Device.groups_ranked.map(&:group).find_index(self.group) + 1
+    Device.groups_ranked
+          .count { |group| group.max_per_core < self.max_per_core } + 1
   end
 
   def config_attributes


### PR DESCRIPTION
Fixes the ranks assigned to groups on a user's profile.

Before, ranks would be assigned incorrectly if there were groups tied with the same emissions. Tied groups would be given consecutive ranks rather than the same value

Before:
![image](https://github.com/openflighthpc/carbon-leaderboard/assets/102584263/5d555d87-c019-4c8b-86a2-3dcc331bbfca)

After:
![image](https://github.com/openflighthpc/carbon-leaderboard/assets/102584263/8ae5d292-eb53-4a68-b8b1-1c93083cc223)
